### PR TITLE
Update kernel/timer.c

### DIFF
--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -175,8 +175,6 @@ void timer_cancel(timer_t *timer)
 	 * periodic timer callback.
 	 */
 	timer->periodic_time = 0;
-	timer->callback = NULL;
-	timer->arg = NULL;
 
 #if PLATFORM_HAS_DYNAMIC_TIMER
 	/* see if we've just modified the head of the timer queue */
@@ -229,8 +227,6 @@ static enum handler_return timer_tick(void *arg, lk_time_t now)
 
 		THREAD_STATS_INC(timers);
 
-		bool periodic = timer->periodic_time > 0;
-
 		LTRACEF("timer %p firing callback %p, arg %p\n", timer, timer->callback, timer->arg);
 		if (timer->callback(timer, now, timer->arg) == INT_RESCHEDULE)
 			ret = INT_RESCHEDULE;
@@ -238,7 +234,7 @@ static enum handler_return timer_tick(void *arg, lk_time_t now)
 		/* if it was a periodic timer and it hasn't been requeued
 		 * by the callback put it back in the list
 		 */
-		if (periodic && !list_in_list(&timer->node) && timer->periodic_time > 0) {
+		if (!list_in_list(&timer->node) && timer->periodic_time > 0) {
 			LTRACEF("periodic timer, period %u\n", (uint)timer->periodic_time);
 			timer->scheduled_time = now + timer->periodic_time;
 			insert_timer_in_queue(timer);


### PR DESCRIPTION
Remove some redundant code and fix a bug where a timer would never be requeued if it converted from normal to periodic inside callback.

In timer_cancel, We don't need to explicitly set timer callback and arg as NULL, They will be updated before/next time the timer is registered with us and inserted in queue.

In timer_tick, periodic variable is redundant and causes a bug where a timer will not be re-inserted into the queue if it changes from non-periodic to periodic inside the callback code, we must requeue based on timer data after callback is complete. If state did change from periodic to non-periodic, statement would still be false as periodic time is set to zero. If timer changed from non-periodic to periodic inside callback, it is never requeued.
