### PR TITLE
Fix possible race in mutex_acquire_timeout

### DIFF
--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -144,7 +144,7 @@ status_t mutex_acquire_timeout(mutex_t *m, lk_time_t timeout)
 
 	enter_critical_section();
 
-	if (unlikely(m->count > 1))
+	if (unlikely(m->count >= 1))
 		ret = wait_queue_block(&m->wait, timeout);
 
 	if (likely(ret == NO_ERROR) {


### PR DESCRIPTION
Fix a possible race condition in mutex acquire timeout, mutex object is not touched if waitqueue returned an error.
