### PR TITLE
Fix ordering for interrupt disable/enable routine

### DIFF
--- a/arch/arm/include/arch/arm/ops.h
+++ b/arch/arm/include/arch/arm/ops.h
@@ -32,13 +32,13 @@
 // override of some routines
 __GNU_INLINE __ALWAYS_INLINE extern inline void arch_enable_ints(void)
 {
-	__asm__("cpsie i");
 	CF;
+	__asm__ volatile("cpsie i");
 }
 
 __GNU_INLINE __ALWAYS_INLINE extern inline void arch_disable_ints(void)
 {
-	__asm__("cpsid i");
+	__asm__ volatile("cpsid i");
 	CF;
 }
 


### PR DESCRIPTION
When exiting a critical section, compiler must store back all scratch registers before interrupts are enabled.
Also prevent reordering of cpsr changes when function is inlined.
