### PR TITLE
[arch][arm] add rules for arm-linux-gnueabi

### DIFF
--- a/arch/arm/rules.mk
+++ b/arch/arm/rules.mk
@@ -177,6 +177,25 @@ FOUNDTOOL=$(shell which $(TOOLCHAIN_PREFIX)gcc)
 ifeq ($(FOUNDTOOL),)
 TOOLCHAIN_PREFIX := arm-none-eabi-
 FOUNDTOOL=$(shell which $(TOOLCHAIN_PREFIX)gcc)
+ifeq ($(FOUNDTOOL),)
+TOOLCHAIN_PREFIX := arm-linux-gnueabi-
+FOUNDTOOL=$(shell which $(TOOLCHAIN_PREFIX)gcc)
+
+# Set no stack protection if we found our gnueabi toolchain. We don't
+# need it.
+#
+# Stack protection is default in this toolchain and we get such errors
+# final linking stage:
+#
+# undefined reference to `__stack_chk_guard'
+# undefined reference to `__stack_chk_fail'
+# undefined reference to `__stack_chk_guard'
+#
+ifneq (,$(findstring arm-linux-gnueabi-,$(FOUNDTOOL)))
+        GLOBAL_COMPILEFLAGS += -fno-stack-protector
+endif
+
+endif
 endif
 endif
 ifeq ($(FOUNDTOOL),)


### PR DESCRIPTION
Add rules for finding arm-linux-gnueabi toolchain and set no stack
protection.

When compiled under this toolchain, we get the following linking errors
in the final stage:

undefined reference to `__stack_chk_guard'
undefined reference to`__stack_chk_fail'
undefined reference to `__stack_chk_guard'

Stack protection is default on this toolchain but we don't need it.
