### PR TITLE
[kernel] Fix for non-timeout waitqueue errors in mutex_acquire_timeout

### DIFF
--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -155,11 +155,11 @@ status_t mutex_acquire_timeout(mutex_t *m, lk_time_t timeout)
 				 * count variable dangerous.
 				 */
 				m->count--;
-				goto err;
 			}
 			/* if there was a general error, it may have been destroyed out from
 			 * underneath us, so just exit (which is really an invalid state anyway)
 			 */
+			goto err;
 		}
 	}
 


### PR DESCRIPTION
This fixes mutex_acquire_timeout for builds with MUTEX_CHECK in-case of non-timeout errors from waitqueue.
