### PR TITLE
Trying to enable usb support and fix compiling problem for am335x

### DIFF
--- a/platform/am335x/rules.mk
+++ b/platform/am335x/rules.mk
@@ -23,6 +23,7 @@ MODULE_SRCS += \
 	$(LOCAL_DIR)/ti/drivers/uart_irda_cir.c \
 	$(LOCAL_DIR)/ti/drivers/dmtimer.c \
 	$(LOCAL_DIR)/ti/drivers/gpio_v2.c \
+	$(LOCAL_DIR)/ti/drivers/usb.c \
 	$(LOCAL_DIR)/ti/interrupt.c \
 
 MODULES += \
@@ -37,6 +38,8 @@ GLOBAL_DEFINES += \
 	MEMBASE=$(MEMBASE) \
 	SDRAM_BASE=$(MEMBASE) \
 	SDRAM_SIZE=$(MEMSIZE) \
+
+GLOBAL_CFLAGS += -Dam335x \
 
 MODULE_DEPS += \
 	lib/cbuf

--- a/platform/am335x/ti/drivers/usb.c
+++ b/platform/am335x/ti/drivers/usb.c
@@ -44,7 +44,7 @@
  */
 
 /* Debug Macros */
-#include "debug.h"
+#include "../include/debug.h"
 
 /* HW Macros and Peripheral Defines */
 #include "hw_types.h"


### PR DESCRIPTION
1. am335x: Convert usb driver from dos format into unix to prevent commit problem.
2. am335x: Trying to enable usb support and fix compiling problem for am335x.
