### PR TITLE
[kernel][smp] reduce impact of SMP code on UP builds

### DIFF
--- a/include/kernel/mp.h
+++ b/include/kernel/mp.h
@@ -30,8 +30,6 @@
 
 __BEGIN_CDECLS;
 
-void mp_init(void);
-
 typedef uint32_t mp_cpu_mask_t;
 
 #define MP_CPU_ALL_BUT_LOCAL (UINT32_MAX)
@@ -41,13 +39,16 @@ typedef uint32_t mp_cpu_mask_t;
  */
 #define MP_RESCHEDULE_FLAG_REALTIME (0x1)
 
-void mp_reschedule(mp_cpu_mask_t target, uint flags);
-void mp_set_curr_cpu_active(bool active);
-
 typedef enum {
     MP_IPI_GENERIC,
     MP_IPI_RESCHEDULE,
 } mp_ipi_t;
+
+#ifdef WITH_SMP
+void mp_init(void);
+
+void mp_reschedule(mp_cpu_mask_t target, uint flags);
+void mp_set_curr_cpu_active(bool active);
 
 /* called from arch code during reschedule irq */
 enum handler_return mp_mbx_reschedule_irq(void);
@@ -93,5 +94,22 @@ static inline mp_cpu_mask_t mp_get_realtime_mask(void)
 {
     return mp.realtime_cpus;
 }
+#else
+static inline void mp_init(void) {}
+static inline void mp_reschedule(mp_cpu_mask_t target, uint flags) {}
+static inline void mp_set_curr_cpu_active(bool active) {}
+
+static inline enum handler_return mp_mbx_reschedule_irq(void) { return 0; }
+
+static inline void mp_set_cpu_idle(uint cpu) {}
+static inline void mp_set_cpu_busy(uint cpu) {}
+
+static inline mp_cpu_mask_t mp_get_idle_mask(void) { return 0; }
+
+static inline void mp_set_cpu_realtime(uint cpu) {}
+static inline void mp_set_cpu_non_realtime(uint cpu) {}
+
+static inline mp_cpu_mask_t mp_get_realtime_mask(void) { return 0; }
+#endif
 
 __END_CDECLS;

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -85,8 +85,10 @@ typedef struct thread {
 	enum thread_state state;
 	int remaining_quantum;
 	unsigned int flags;
+#if WITH_SMP
 	int curr_cpu;
 	int pinned_cpu; /* only run on pinned_cpu if >= 0 */
+#endif
 
 	/* if blocked, a pointer to the wait queue */
 	struct wait_queue *blocking_wait_queue;
@@ -112,6 +114,18 @@ typedef struct thread {
 
 	char name[32];
 } thread_t;
+
+#if WITH_SMP
+#define thread_curr_cpu(t) ((t)->curr_cpu)
+#define thread_pinned_cpu(t) ((t)->pinned_cpu)
+#define thread_set_curr_cpu(t,c) ((t)->curr_cpu = (c))
+#define thread_set_pinned_cpu(t, c) ((t)->pinned_cpu = (c))
+#else
+#define thread_curr_cpu(t) (0)
+#define thread_pinned_cpu(t) (-1)
+#define thread_set_curr_cpu(t,c) do {} while(0)
+#define thread_set_pinned_cpu(t, c) do {} while(0)
+#endif
 
 /* thread priority */
 #define NUM_PRIORITIES 32

--- a/kernel/mp.c
+++ b/kernel/mp.c
@@ -32,6 +32,7 @@
 
 #define LOCAL_TRACE 0
 
+#if WITH_SMP
 /* a global state structure, aligned on cpu cache line to minimize aliasing */
 struct mp_state mp __CPU_ALIGN;
 
@@ -41,7 +42,6 @@ void mp_init(void)
 
 void mp_reschedule(mp_cpu_mask_t target, uint flags)
 {
-#if WITH_SMP
 	uint local_cpu = arch_curr_cpu_num();
 
 	LTRACEF("local %d, target 0x%x\n", local_cpu, target);
@@ -58,7 +58,6 @@ void mp_reschedule(mp_cpu_mask_t target, uint flags)
 	LTRACEF("local %d, post mask target now 0x%x\n", local_cpu, target);
 
 	arch_mp_send_ipi(target, MP_IPI_RESCHEDULE);
-#endif
 }
 
 void mp_set_curr_cpu_active(bool active)
@@ -66,7 +65,6 @@ void mp_set_curr_cpu_active(bool active)
 	atomic_or((volatile int *)&mp.active_cpus, 1U << arch_curr_cpu_num());
 }
 
-#if WITH_SMP
 enum handler_return mp_mbx_reschedule_irq(void)
 {
 	uint cpu = arch_curr_cpu_num();

--- a/top/main.c
+++ b/top/main.c
@@ -121,7 +121,7 @@ void lk_main(ulong arg0, ulong arg1, ulong arg2, ulong arg3)
     // create a thread to complete system initialization
     dprintf(SPEW, "creating bootstrap completion thread\n");
     thread_t *t = thread_create("bootstrap2", &bootstrap2, NULL, DEFAULT_PRIORITY, DEFAULT_STACK_SIZE);
-    t->pinned_cpu = 0;
+    thread_set_pinned_cpu(t, 0);
     thread_detach(t);
     thread_resume(t);
 


### PR DESCRIPTION
Hopefully to nothing...
- remove current/pinned cpu tracking in thread struct
- macroize access to current/pinned cpu tracking
- empty-inline/remove vestigial mp_* bits in UP builds