### PR TITLE
[init] removed test code from target init

### DIFF
--- a/lib/libc/atexit.c
+++ b/lib/libc/atexit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008 Travis Geiselbrecht
+ * Copyright (c) 2008-2015 Travis Geiselbrecht
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files

--- a/lib/libc/eabi.c
+++ b/lib/libc/eabi.c
@@ -23,6 +23,8 @@
 /* some cruft we have to define when using the linux toolchain */
 #include <unwind.h>
 
+void *__dso_handle;
+
 #if defined(__ARM_EABI_UNWINDER__) && __ARM_EABI_UNWINDER__
 
 /* Our toolchain has eabi functionality built in, but they're not really used.
@@ -48,4 +50,13 @@ _Unwind_Reason_Code __aeabi_unwind_cpp_pr2(_Unwind_State state, _Unwind_Control_
 void raise(void)
 {
 }
+
+extern int __cxa_atexit(void (*func)(void *), void *arg, void *d);
+
+int __aeabi_atexit(void *arg, void (*func)(void *), void *d)
+{
+    return __cxa_atexit(func, arg, d);
+}
+
+
 

--- a/lib/libc/pure_virtual.cpp
+++ b/lib/libc/pure_virtual.cpp
@@ -27,3 +27,8 @@ extern "C" void __cxa_pure_virtual(void)
     panic("pure virtual called\n");
 }
 
+extern "C" int __cxa_atexit(void (*destructor)(void *), void *arg, void *__dso_handle)
+{
+    return 0;
+}
+

--- a/target/nrf-pca10000/init.c
+++ b/target/nrf-pca10000/init.c
@@ -53,28 +53,9 @@ void target_early_init(void)
     nrf51_debug_early_init();
 }
 
-static enum handler_return blinker(timer_t *timer, lk_time_t now, void *args)
-{
-
-    if (heartbeat) {
-        heartbeat = false;
-        gpio_set(GPIO_LED1,1); //turn off led
-        timer_set_oneshot(timer,950, blinker, NULL);
-    } else {
-        heartbeat = true;
-        gpio_set(GPIO_LED1,0);
-        timer_set_oneshot(timer,50, blinker, NULL);
-    }
-    return INT_RESCHEDULE;
-}
-
-
-
 
 void target_init(void)
 {
     nrf51_debug_init();
     dprintf(SPEW,"Target: PCA10000 DK...\n");
-    timer_initialize(&blinktimer);
-    timer_set_oneshot(&blinktimer, 1000, blinker, NULL);
 }


### PR DESCRIPTION
Removed test code that was accidentally left in init for the pca10000 development kit target.