### PR TITLE
[arch][x86] load initial stack pointer in boot entry

### DIFF
--- a/arch/x86/32/start.S
+++ b/arch/x86/32/start.S
@@ -89,6 +89,9 @@ real_start:
     movw %ax, %gs
     movw %ax, %ss
 
+    /* load inital stack pointer */
+    movl $PHYS(_kstack + 4096), %esp
+
     /*We jumped here in protected mode in a code segment that migh not longer
       be valid , do a long jump to our code segment, we use retf instead of
       ljmp to be able to use relative labels */

--- a/arch/x86/64/start.S
+++ b/arch/x86/64/start.S
@@ -94,6 +94,9 @@ real_start:
     movw %ax, %gs
     movw %ax, %ss
 
+    /* load inital stack pointer */
+    movl $PHYS(_kstack + 4096), %esp
+
     /* We need to jump to our sane 32 bit CS */
     pushl $CODE_SELECTOR
     pushl $PHYS(.Lfarjump)


### PR DESCRIPTION
Initially, stack pointer (esp) is undefined in multiboot protocol,
to avoid potential memory corruption, set it with defined value.

Signed-off-by: Zhu, Bing <bing.zhu@intel.com>