### PR TITLE
[ndebug] Move ndebug reset handshake from user endpoint to all endpoi…

### DIFF
--- a/app/ndebugtest/ndebugtest.c
+++ b/app/ndebugtest/ndebugtest.c
@@ -68,7 +68,7 @@ static void ndebugtest_entry(const struct app_descriptor *app, void *args)
     while (true) {
         // Wait for USB to connect and somebody to answer the phone on the other
         // end of the line.
-        status_t result = ndebugusr_await_host(INFINITE_TIME);
+        status_t result = ndebug_await_connection_usr(INFINITE_TIME);
         if (result != NO_ERROR) {
             printf("Error %d while awaiting host. Retrying...\n", result);
             continue;

--- a/lib/ndebug/include/lib/ndebug/ndebug.h
+++ b/lib/ndebug/include/lib/ndebug/ndebug.h
@@ -46,6 +46,8 @@ ssize_t ndebug_usb_read(const channel_t ch, const size_t n,
 ssize_t ndebug_usb_write(const channel_t ch, const size_t n,
                          const lk_time_t timeout, uint8_t *buf);
 
-status_t await_usb_online(lk_time_t timeout);
+status_t ndebug_await_connection(const channel_t ch, const lk_time_t timeout);
 
+status_t msg_host(const channel_t ch, const uint32_t message,
+                  const lk_time_t timeout, uint8_t *buf);
 __END_CDECLS

--- a/lib/ndebug/include/lib/ndebug/user.h
+++ b/lib/ndebug/include/lib/ndebug/user.h
@@ -38,6 +38,6 @@ ssize_t ndebug_write_usr(uint8_t *buf, const size_t n, const lk_time_t timeout);
 
 
 // Wait for the host to establish a connection on the usr channel.
-status_t ndebugusr_await_host(lk_time_t timeout);
+status_t ndebug_await_connection_usr(lk_time_t timeout);
 
 __END_CDECLS


### PR DESCRIPTION
…nts.

NDebug sits and waits for a reset message before becoming active. I intend to
use this handshake for the system debug protocol as well as the high level
protocol so I'm pulling the logic for it up into the core ndebug utility
functions.