### PR TITLE
[spifs] Fix warning with GCC 5.3.1

### DIFF
--- a/lib/fs/spifs/spifs.c
+++ b/lib/fs/spifs/spifs.c
@@ -152,9 +152,11 @@ static status_t cursor_init(
 
 static uint8_t *cursor_get(cursor_t *cursor)
 {
+#if LK_DEBUGLEVEL > 1
     spifs_t *spifs = cursor->spifs;
 
     uint8_t *page_end = spifs->page + spifs->page_size;
+#endif
     DEBUG_ASSERT(cursor->data < page_end);
 
     return cursor->data;
@@ -336,8 +338,10 @@ static status_t spifs_commit_toc(spifs_t *spifs)
 
     // Sanity check. The cursor should be at the last position in this page
     // at this point.
+#if LK_DEBUGLEVEL > 1
     uint8_t *expected_cursor_location =
         (spifs->page + spifs->page_size) - SPIFS_ENTRY_LENGTH;
+#endif
     DEBUG_ASSERT(cursor == expected_cursor_location);
 
     toc_footer_t *footer = (toc_footer_t *)cursor;

--- a/lib/fs/spifs/spifs.c
+++ b/lib/fs/spifs/spifs.c
@@ -156,8 +156,8 @@ static uint8_t *cursor_get(cursor_t *cursor)
     spifs_t *spifs = cursor->spifs;
 
     uint8_t *page_end = spifs->page + spifs->page_size;
-#endif
     DEBUG_ASSERT(cursor->data < page_end);
+#endif
 
     return cursor->data;
 }
@@ -341,8 +341,8 @@ static status_t spifs_commit_toc(spifs_t *spifs)
 #if LK_DEBUGLEVEL > 1
     uint8_t *expected_cursor_location =
         (spifs->page + spifs->page_size) - SPIFS_ENTRY_LENGTH;
-#endif
     DEBUG_ASSERT(cursor == expected_cursor_location);
+#endif
 
     toc_footer_t *footer = (toc_footer_t *)cursor;
     memset(footer, 0, SPIFS_ENTRY_LENGTH);


### PR DESCRIPTION
With GCC 5.3.1 (5-2016-q2-update from https://launchpad.net/gcc-arm-embedded)
additional warnings about unused variables cause compilation to fail.