### PR TITLE
[wait-queue] fix wake all to remove threads from tail

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1217,7 +1217,7 @@ int wait_queue_wake_all(wait_queue_t *wait, bool reschedule, status_t wait_queue
     }
 
     /* pop all the threads off the wait queue into the run queue */
-    while ((t = list_remove_head_type(&wait->list, thread_t, queue_node))) {
+    while ((t = list_remove_tail_type(&wait->list, thread_t, queue_node))) {
         wait->count--;
         DEBUG_ASSERT(t->state == THREAD_BLOCKED);
         t->state = THREAD_READY;


### PR DESCRIPTION
While waking up all threads from wait-queue, order should
start from tail to maintain correct scheduling sequence.

Signed-off-by: Mahavir Jain <mahavirpj@gmail.com>