### PR TITLE
[make] don't call build engine multiple times.

### DIFF
--- a/engine.mk
+++ b/engine.mk
@@ -24,6 +24,7 @@ ifneq ($(project-name),)
 ifneq ($(strip $(foreach d,$(LKINC),$(wildcard $(d)/project/$(project-name).mk))),)
 do-nothing := 1
 $(MAKECMDGOALS) _all: make-make
+	@:
 make-make:
 	@PROJECT=$(project-name) $(MAKE) -rR -f $(LOCAL_MAKEFILE) $(filter-out $(project-name), $(MAKECMDGOALS))
 

--- a/makefile
+++ b/makefile
@@ -28,9 +28,16 @@ export BUILDROOT
 export DEFAULT_PROJECT
 export TOOLCHAIN_PREFIX
 
-# vaneer makefile that calls into the engine with lk as the build root
+# veneer makefile that calls into the engine with lk as the build root
 # if we're the top level invocation, call ourselves with additional args
-$(MAKECMDGOALS) _top:
+_top:
 	@$(MAKE) -C $(LKMAKEROOT) -rR -f $(LKROOT)/engine.mk $(addprefix -I,$(LKINC)) $(MAKECMDGOALS)
+
+# If any arguments were provided, create a recipe for them that depends
+# on the _top rule (thus calling it), but otherwise do nothing.
+# "@:" (vs empty rule ";") prevents extra "'foo' is up to date." messages from
+# being emitted.
+$(MAKECMDGOALS): _top
+	@:
 
 .PHONY: _top


### PR DESCRIPTION
If some included rule.mk defines an additional make target that the user
might want to call (e.g., "flash"), and user specifies a project name on
the command line, then previously the outer "makefile" would call
engine.mk multiple times. The new logic prevents that.

Additionally, silence extra "Nothing to be done" messages when calling
engine.mk again after removing the project name from make goals.