### PR TITLE
[dev/gpio_i2c] add optional pullups

### DIFF
--- a/dev/gpio_i2c/rules.mk
+++ b/dev/gpio_i2c/rules.mk
@@ -1,3 +1,10 @@
+# I2C bit-banging using GPIO lines.
+#
+# Before including the module, define:
+#
+#   GPIO_I2C_BUS_COUNT: number of SDA/SCL pairs to be used.
+#   GPIO_I2C_PULLUPS (optional): if 1, enables pullups.
+
 LOCAL_DIR := $(GET_LOCAL_DIR)
 
 MODULE := $(LOCAL_DIR)
@@ -7,5 +14,10 @@ MODULE_SRCS := \
 
 MODULE_DEFINES += \
 	GPIO_I2C_BUS_COUNT=$(GPIO_I2C_BUS_COUNT)
+
+ifneq ($(GPIO_I2C_PULLUPS),)
+MODULE_DEFINES += \
+	GPIO_I2C_PULLUPS=$(GPIO_I2C_PULLUPS)
+endif
 
 include make/module.mk


### PR DESCRIPTION
If GPIO_I2C_PULLUPS == 1, enables pullups when not actively
driving I2C lines low.