### PR TITLE
[make] [lib/version] remove a misplaced .PHONY

### DIFF
--- a/engine.mk
+++ b/engine.mk
@@ -73,7 +73,7 @@ ARCH_CPPFLAGS :=
 ARCH_ASMFLAGS :=
 
 # top level rule
-all:: $(OUTBIN) $(OUTELF).lst $(OUTELF).debug.lst $(OUTELF).sym $(OUTELF).sym.sorted $(OUTELF).size $(OUTELF).dump
+all:: $(OUTBIN) $(OUTELF).lst $(OUTELF).debug.lst $(OUTELF).sym $(OUTELF).sym.sorted $(OUTELF).size $(OUTELF).dump $(BUILDDIR)/srcfiles.txt $(BUILDDIR)/include_paths.txt
 
 # master module object list
 ALLOBJS_MODULE :=

--- a/lib/version/rules.mk
+++ b/lib/version/rules.mk
@@ -16,13 +16,14 @@ BUILDID := "$(shell $(LOCAL_DIR)/buildid.sh)_LOCAL"
 endif
 endif
 
-# Generate a buildid.h file, lazy evaulated BUILDID_DEFINE at the end
+# Generate a buildid.h file, lazy evaluate BUILDID_DEFINE at the end
 # of the first make pass. This lets modules that haven't been
 # included yet set BUILDID.
 BUILDID_DEFINE="BUILDID=\"$(BUILDID)\""
 BUILDID_H := $(BUILDDIR)/buildid.h
-$(BUILDID_H): .PHONY
+$(BUILDID_H):
 	@$(call MAKECONFIGHEADER,$@,BUILDID_DEFINE)
+.PHONY: $(BUILDID_H)
 
 GENERATED += $(BUILDID_H)
 

--- a/make/build.mk
+++ b/make/build.mk
@@ -54,13 +54,9 @@ $(BUILDDIR)/srcfiles.txt:
 	@echo generating $@
 	$(NOECHO)echo $(sort $(ALLSRCS)) | tr ' ' '\n' > $@
 
-.PHONY: $(BUILDDIR)/srcfiles.txt
-
 $(BUILDDIR)/include_paths.txt:
 	@echo generating $@
 	$(NOECHO)echo $(subst -I,,$(sort $(GLOBAL_INCLUDES))) | tr ' ' '\n' > $@
-
-.PHONY: $(BUILDDIR)/include_paths.txt
 
 #include arch/$(ARCH)/compile.mk
 


### PR DESCRIPTION
When lib/version was included, a rule depended on .PHONY.  This would
unexpectedly invoke other rules defined as dependent on .PHONY (standard
phony-ness signal).

As a side effect, this used to generate srcfiles.txt and
include_paths.txt in build dir. Since they are useful, we might always
build those anyway, and not make them phony at all.