### PR TITLE
[lib][sysparam] free hexbuffer in error path

### DIFF
--- a/lib/sysparam/sysparam.c
+++ b/lib/sysparam/sysparam.c
@@ -514,6 +514,7 @@ static ssize_t hexstr_to_val(const char *str, uint8_t **buf)
         uint8_t c = str[pos];
 
         if (!isxdigit(c)) {
+            free(hexbuffer);
             return ERR_NOT_VALID;
         }
 


### PR DESCRIPTION
free hexbuffer in error path of hexstr_to_val()