### PR TITLE
[build] add deps for srcfiles.txt and include_paths.txt

### DIFF
--- a/make/build.mk
+++ b/make/build.mk
@@ -50,11 +50,11 @@ $(OUTELF).size: $(OUTELF)
 	$(NOECHO)$(NM) -S --size-sort $< > $@
 
 # print some information about the build
-$(BUILDDIR)/srcfiles.txt:
+$(BUILDDIR)/srcfiles.txt: $(OUTELF)
 	@echo generating $@
 	$(NOECHO)echo $(sort $(ALLSRCS)) | tr ' ' '\n' > $@
 
-$(BUILDDIR)/include_paths.txt:
+$(BUILDDIR)/include_paths.txt: $(OUTELF)
 	@echo generating $@
 	$(NOECHO)echo $(subst -I,,$(sort $(GLOBAL_INCLUDES))) | tr ' ' '\n' > $@
 


### PR DESCRIPTION
Without the dependencies, the files get written once and don't get
updated when include paths or source files change.