### PR TITLE
Bug fix on SMAP/SMEP detection and float test.

### DIFF
--- a/app/tests/float.c
+++ b/app/tests/float.c
@@ -38,6 +38,17 @@ extern void float_vfp_thumb_instruction_test(void);
 extern void float_neon_arm_instruction_test(void);
 extern void float_neon_thumb_instruction_test(void);
 
+static float test_result[] = {
+    47822.828125,
+    69934.515625,
+    92046.062500,
+    114157.406250,
+    136270.421875,
+    158378.812500,
+    180492.656250,
+    202600.265625,
+};
+
 #if !ARM_WITH_VFP_SP_ONLY
 #define FLOAT float
 #else
@@ -107,9 +118,8 @@ static void float_tests(void)
     int res;
     for (uint i = 0; i < countof(t); i++) {
         thread_join(t[i], &res, INFINITE_TIME);
-        printf("float thread %u returns %d, val %f\n", i, res, val[i]);
+        printf("float thread %u returns %d, val %f, expected:%f\n", i, res, val[i], test_result[i]);
     }
-    printf("the above values should be close\n");
 
 #if ARCH_ARM && !ARM_ISA_ARMV7M
     /* test all the instruction traps */

--- a/arch/x86/include/arch/x86.h
+++ b/arch/x86/include/arch/x86.h
@@ -38,6 +38,8 @@ __BEGIN_CDECLS
 #define PFEX_I 0x10
 #define X86_8BYTE_MASK 0xFFFFFFFF
 #define X86_CPUID_ADDR_WIDTH 0x80000008
+#define X86_CPUID_SMEP_BIT 0x07
+#define X86_CPUID_SMAP_BIT 0x14
 
 struct x86_32_iframe {
     uint32_t di, si, bp, sp, bx, dx, cx, ax;            // pushed by common handler using pusha
@@ -497,7 +499,7 @@ static inline uint32_t check_smep_avail(void)
         "cpuid \n\t"
         :"=b" (reg_b)
         :"a" (reg_a),"c" (reg_c));
-    return ((reg_b>>0x06) & 0x1);
+    return ((reg_b >> X86_CPUID_SMEP_BIT) & 0x1);
 }
 
 static inline uint32_t check_smap_avail(void)
@@ -509,7 +511,7 @@ static inline uint32_t check_smap_avail(void)
         "cpuid \n\t"
         :"=b" (reg_b)
         :"a" (reg_a),"c" (reg_c));
-    return ((reg_b>>0x13) & 0x1);
+    return ((reg_b >> X86_CPUID_SMAP_BIT) & 0x1);
 }
 #endif // ARCH_X86_32
 
@@ -828,7 +830,7 @@ static inline uint64_t check_smep_avail(void)
         "cpuid \n\t"
         :"=b" (reg_b)
         :"a" (reg_a),"c" (reg_c));
-    return ((reg_b>>0x06) & 0x1);
+    return ((reg_b >> X86_CPUID_SMEP_BIT) & 0x1);
 }
 
 static inline uint64_t check_smap_avail(void)
@@ -840,7 +842,7 @@ static inline uint64_t check_smap_avail(void)
         "cpuid \n\t"
         :"=b" (reg_b)
         :"a" (reg_a),"c" (reg_c));
-    return ((reg_b>>0x13) & 0x1);
+    return ((reg_b >> X86_CPUID_SMAP_BIT) & 0x1);
 }
 
 #endif // ARCH_X86_64


### PR DESCRIPTION
Hi Travisg,
There is an bug on x86 architecture code: SMAP/SMEP detection, SMAP is bit 7 and SMEP is bit 20 while invoking CPU with subleaf 07H.
To float test case, since test case updated, test results for each thread should not similar now. Array of expected test result added to help check whether test result for each thread is correct.