### PR TITLE
[lib][bio] fix compile warning with arch/arm64

### DIFF
--- a/lib/bio/bio.c
+++ b/lib/bio/bio.c
@@ -332,7 +332,7 @@ size_t bio_trim_range(const bdev_t *dev, off_t offset, size_t len)
         return 0;
     if (len == 0)
         return 0;
-    if (offset + len > dev->total_size)
+    if ((off_t)(offset + len) > dev->total_size)
         len = dev->total_size - offset;
 
     return len;


### PR DESCRIPTION
lib/bio/bio.c:345:22: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]

Signed-off-by: Tristan Shieh <tristan.shieh@mediatek.com>