### PR TITLE
Fix two multiboot for x86

### DIFF
--- a/platform/pc/include/platform/multiboot.h
+++ b/platform/pc/include/platform/multiboot.h
@@ -91,12 +91,12 @@ enum {
     MB_INFO_CMD_LINE    = 0x004,
     MB_INFO_MODS        = 0x008,
     MB_INFO_SYMS        = 0x010,
-    MB_INFO_MMAP        = 0x020,
-    MB_INFO_DRIVES      = 0x040,
-    MB_INFO_CONFIG      = 0x080,
-    MB_INFO_BOOT_LOADER = 0x100,
-    MB_INFO_APM_TABLE   = 0x200,
-    MB_INFO_VBE         = 0x400,
+    MB_INFO_MMAP        = 0x040,
+    MB_INFO_DRIVES      = 0x080,
+    MB_INFO_CONFIG      = 0x100,
+    MB_INFO_BOOT_LOADER = 0x200,
+    MB_INFO_APM_TABLE   = 0x400,
+    MB_INFO_VBE         = 0x800,
 };
 
 /* module structure */

--- a/platform/pc/platform.c
+++ b/platform/pc/platform.c
@@ -191,7 +191,7 @@ void platform_init_multiboot_info(void)
         }
 
         if (_multiboot_info->flags & MB_INFO_MMAP) {
-            memory_map_t *mmap = (memory_map_t *)(uintptr_t)(_multiboot_info->mmap_addr - 4);
+            memory_map_t *mmap = (memory_map_t *)(uintptr_t)_multiboot_info->mmap_addr;
             mmap = (void *)((uintptr_t)mmap + KERNEL_BASE);
 
             LTRACEF("memory map:\n");


### PR DESCRIPTION
Several multiboot constants are off per the multiboot spec, leading to incorrect booting:

https://www.gnu.org/software/grub/manual/multiboot/multiboot.html