### PR TITLE
[arch][x86] x86-64 related update, including TSS, TR, GS which will be used in SMP

### DIFF
--- a/arch/x86/64/exceptions.S
+++ b/arch/x86/64/exceptions.S
@@ -25,12 +25,19 @@
 #include <asm.h>
 #include <arch/x86/descriptor.h>
 
-#define NUM_INT 0x31
+#define NUM_INT 0x100
 #define NUM_EXC 0x14
 
 .text
 
 /* interrupt service routine stubs */
+
+/*
+ * pushq $i occupies 5 bytes when i >= 0x80 compare to
+ * 2 bytes when i < 0x80, needs to add 3 nops instruction
+ * to fill the gap to make sure isr_stub_len correct for
+ * each interrupts
+ */
 _isr:
 .set i, 0
 .rept NUM_INT
@@ -38,14 +45,22 @@ _isr:
 .set isr_stub_start, .
 
 .if i == 8 || (i >= 10 && i <= 14) || i == 17
-        nop                                     /* error code pushed by exception */
-        nop                                     /* 2 nops are the same length as push byte */
-        pushq $i                                /* interrupt number */
-        jmp interrupt_common
+    nop             /* error code pushed by exception */
+    nop             /* 2 nops are the same length as push byte */
+    pushq $i        /* interrupt number */
+    nop
+    nop
+    nop
+    jmp interrupt_common
 .else
-        pushq $0                                /* fill in error code in iframe */
-        pushq $i                                /* interrupt number */
-        jmp interrupt_common
+    pushq $0        /* fill in error code in iframe */
+    pushq $i        /* interrupt number */
+.if i < 0x80
+    nop
+    nop
+    nop
+.endif
+    jmp interrupt_common
 .endif
 
 /* figure out the length of a single isr stub (usually 6 or 9 bytes) */
@@ -137,7 +152,7 @@ DATA(_idtr)
 DATA(_idt)
 
 .set i, 0
-.rept NUM_INT-1
+.rept NUM_INT
     .short 0        /* low 16 bits of ISR offset (_isr#i & 0FFFFh) */
     .short CODE_64_SELECTOR   /* selector */
     .byte  0

--- a/arch/x86/64/start.S
+++ b/arch/x86/64/start.S
@@ -218,6 +218,11 @@ farjump64:
     jmp  *%rax
 
 highaddr:
+	/* set TR now, since lk_main check cpu_id when initialing thread */
+	xorq %rax, %rax
+	mov $TSS_SELECTOR, %ax
+	ltr %ax
+
     /* load the high kernel stack */
     mov  $(_kstack + 4096), %rsp
 

--- a/arch/x86/gdt.S
+++ b/arch/x86/gdt.S
@@ -56,85 +56,89 @@ DATA(_gdt)
 _code_32_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b10011010       /* P(1) DPL(00) S(1) 1 C(0) R(1) A(0) */
     .byte  0b11001111       /* G(1) D(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set datasel, . - _gdt
 _data_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b10010010       /* P(1) DPL(00) S(1) 0 E(0) W(1) A(0) */
     .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set user_codesel_32, . - _gdt
 _user_code_32_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b11111010       /* P(1) DPL(11) S(1) 1 C(0) R(1) A(0) */
     .byte  0b11001111       /* G(1) D(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 
 .set user_datasel, . - _gdt
 _user_data_32_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b11110010       /* P(1) DPL(11) S(1) 0 E(0) W(1) A(0) */
     .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set codesel_64, . - _gdt
 _code_64_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b10011010       /* P(1) DPL(00) S(1) 1 C(0) R(1) A(0) */
     .byte  0b10101111       /* G(1) D(0) L(1) AVL(0) limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set datasel_64, . - _gdt
 _data_64_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b10010010       /* P(1) DPL(00) S(1) 1 C(0) R(1) A(0) */
     .byte  0b11001111       /* G(1) B(1) 0 AVL(0) limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set user_codesel_64, . - _gdt
 _user_code_64_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b11111010       /* P(1) DPL(11) S(1) 1 C(0) R(1) A(0) */
     .byte  0b10101111       /* G(1) D(1) L(0) AVL(0) limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set user_datasel_64, . - _gdt
 _user_data_64_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b11110010       /* P(1) DPL(11) S(1) 0 E(0) W(1) A(0) */
     .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 /* TSS descriptor */
 .set tsssel, . - _gdt
+.set i, 1
+.rept SMP_MAX_CPUS
 _tss_gde:
     .short 0                /* limit 15:00 */
     .short 0                /* base 15:00 */
     .byte  0                /* base 23:16 */
-    .byte  0x89             /* P(1) DPL(11) 0 10 B(0) 1 */
-    .byte  0x80             /* G(0) 0 0 AVL(0) limit 19:16 */
-    .byte  0               /* base 31:24 */
+    .byte  0x89             /* P(1) DPL(00) S(0) TYPE(9) */
+    .byte  0x80             /* G(1) D/B(0) L(0) AVL(0) limit 19:16 */
+    .byte  0                /* base 31:24 */
     .quad  0x0000000000000000
+.set i, i+1
+.endr
 
 DATA(_gdt_end)
 

--- a/arch/x86/include/arch/x86.h
+++ b/arch/x86/include/arch/x86.h
@@ -136,24 +136,27 @@ typedef tss_32_t tss_t;
 typedef tss_64_t tss_t;
 #endif
 
-#define X86_CR0_PE 0x00000001 /* protected mode enable */
-#define X86_CR0_MP 0x00000002 /* monitor coprocessor */
-#define X86_CR0_EM 0x00000004 /* emulation */
-#define X86_CR0_TS 0x00000008 /* task switched */
-#define X86_CR0_NE 0x00000020 /* enable x87 exception */
-#define X86_CR0_WP 0x00010000 /* supervisor write protect */
-#define X86_CR0_NW 0x20000000 /* not write-through */
-#define X86_CR0_CD 0x40000000 /* cache disable */
-#define X86_CR0_PG 0x80000000 /* enable paging */
-#define X86_CR4_PAE 0x00000020 /* PAE paging */
-#define X86_CR4_OSFXSR 0x00000200 /* os supports fxsave */
-#define X86_CR4_OSXMMEXPT 0x00000400 /* os supports xmm exception */
-#define X86_CR4_OSXSAVE 0x00040000 /* os supports xsave */
-#define X86_CR4_SMEP 0x00100000 /* SMEP protection enabling */
-#define X86_CR4_SMAP 0x00200000 /* SMAP protection enabling */
-#define x86_EFER_NXE 0x00000800 /* to enable execute disable bit */
-#define x86_MSR_EFER 0xc0000080 /* EFER Model Specific Register id */
-#define X86_CR4_PSE 0xffffffef /* Disabling PSE bit in the CR4 */
+#define X86_CR0_PE              0x00000001 /* protected mode enable */
+#define X86_CR0_MP              0x00000002 /* monitor coprocessor */
+#define X86_CR0_EM              0x00000004 /* emulation */
+#define X86_CR0_TS              0x00000008 /* task switched */
+#define X86_CR0_NE              0x00000020 /* enable x87 exception */
+#define X86_CR0_WP              0x00010000 /* supervisor write protect */
+#define X86_CR0_NW              0x20000000 /* not write-through */
+#define X86_CR0_CD              0x40000000 /* cache disable */
+#define X86_CR0_PG              0x80000000 /* enable paging */
+#define X86_CR4_PAE             0x00000020 /* PAE paging */
+#define X86_CR4_OSFXSR          0x00000200 /* os supports fxsave */
+#define X86_CR4_OSXMMEXPT       0x00000400 /* os supports xmm exception */
+#define X86_CR4_FSGSBASE        0x00010000 /* gsbase/fsbase instruction enable bit */
+#define X86_CR4_OSXSAVE         0x00040000 /* os supports xsave */
+#define X86_CR4_SMEP            0x00100000 /* SMEP protection enabling */
+#define X86_CR4_SMAP            0x00200000 /* SMAP protection enabling */
+#define x86_EFER_NXE            0x00000800 /* to enable execute disable bit */
+#define x86_MSR_EFER            0xc0000080 /* EFER Model Specific Register id */
+#define x86_MSR_GS_BASE         0xc0000080 /* Map of base address of GS */
+#define x86_MSR_KRNL_GS_BASE    0xc0000080 /* Swap target of base address of GS */
+#define X86_CR4_PSE             0xffffffef /* Disabling PSE bit in the CR4 */
 
 #if ARCH_X86_32
 static inline void set_in_cr0(uint32_t mask)
@@ -382,7 +385,7 @@ static inline uint64_t read_msr (uint32_t msr_id)
 
     __asm__ __volatile__ (
         "rdmsr \n\t"
-        : "=a" (low_val), "=d"(high_val)
+        : "=a" (low_val), "=d" (high_val)
         : "c" (msr_id));
 
     msr_read_val = high_val;
@@ -398,7 +401,7 @@ static inline void write_msr (uint32_t msr_id, uint64_t msr_write_val)
 
     __asm__ __volatile__ (
         "wrmsr \n\t"
-        : : "c" (msr_id), "a" (low_val), "d"(high_val));
+        : : "c" (msr_id), "a" (low_val), "d" (high_val));
 }
 
 static inline uint32_t x86_get_cr3(void)
@@ -497,7 +500,7 @@ static inline uint32_t check_smep_avail(void)
         "cpuid \n\t"
         :"=b" (reg_b)
         :"a" (reg_a),"c" (reg_c));
-    return ((reg_b>>0x06) & 0x1);
+    return ((reg_b>>0x07) & 0x1);
 }
 
 static inline uint32_t check_smap_avail(void)
@@ -509,7 +512,7 @@ static inline uint32_t check_smap_avail(void)
         "cpuid \n\t"
         :"=b" (reg_b)
         :"a" (reg_a),"c" (reg_c));
-    return ((reg_b>>0x13) & 0x1);
+    return ((reg_b>>0x14) & 0x1);
 }
 #endif // ARCH_X86_32
 
@@ -729,7 +732,7 @@ static inline uint64_t read_msr (uint32_t msr_id)
 
     __asm__ __volatile__ (
         "rdmsr \n\t"
-        : "=a" (low_val), "=d"(high_val)
+        : "=a" (low_val), "=d" (high_val)
         : "c" (msr_id));
 
     msr_read_val = high_val;
@@ -745,7 +748,7 @@ static inline void write_msr (uint32_t msr_id, uint64_t msr_write_val)
 
     __asm__ __volatile__ (
         "wrmsr \n\t"
-        : : "c" (msr_id), "a" (low_val), "d"(high_val));
+        : : "c" (msr_id), "a" (low_val), "d" (high_val));
 }
 
 static inline uint64_t x86_get_cr3(void)
@@ -828,7 +831,7 @@ static inline uint64_t check_smep_avail(void)
         "cpuid \n\t"
         :"=b" (reg_b)
         :"a" (reg_a),"c" (reg_c));
-    return ((reg_b>>0x06) & 0x1);
+    return ((reg_b>>0x07) & 0x1);
 }
 
 static inline uint64_t check_smap_avail(void)
@@ -840,7 +843,28 @@ static inline uint64_t check_smap_avail(void)
         "cpuid \n\t"
         :"=b" (reg_b)
         :"a" (reg_a),"c" (reg_c));
-    return ((reg_b>>0x13) & 0x1);
+    return ((reg_b>>0x14) & 0x1);
+}
+
+static inline uint64_t x86_read_gs_with_offset(uintptr_t offset)
+{
+    uint64_t ret;
+
+    __asm__ __volatile__ (
+        "movq %%gs:%1, %0"
+        :"=r" (ret)
+        :"m" (*(uint64_t *)offset));
+
+    return ret;
+}
+
+static inline void x86_write_gs_with_offset(uint64_t offset, uint64_t val)
+{
+    __asm__ __volatile__ (
+        "movq %0, %%gs:%1"
+        :
+        :"ir" (val), "m" (*(uint64_t *)offset)
+        :"memory");
 }
 
 #endif // ARCH_X86_64


### PR DESCRIPTION
1. Update TSS selector description.
2. Enlarge TSS selector up to SMP_MAX_CPUS.
3. Enlarge interrupt numbers support to 0xFF in arch x86-64.

Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>