### PR TITLE
(Very) minor documentation comment change to timer implementation.

### DIFF
--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -149,7 +149,7 @@ void timer_set_oneshot(timer_t *timer, lk_time_t delay, timer_callback callback,
  * delay.  The function will be called repeatedly.
  *
  * @param  timer The timer to use
- * @param  delay The delay, in ms, before the timer is executed
+ * @param  period The delay, in ms, between timer executions (first execution occurs one period after timer set)
  * @param  callback  The function to call when the timer expires
  * @param  arg  The argument to pass to the callback
  *


### PR DESCRIPTION
Incredibly minor documentation comment change. The comment for `timer_set_periodic` mentioned a non-existent parameter `delay` rather than the `period` argument --- perhaps a copy+paste error from the doc comment for timer_set_oneshot!