### PR TITLE
Project: add platform/target/project support of mt6735

### DIFF
--- a/platform/mediatek/common/rules.mk
+++ b/platform/mediatek/common/rules.mk
@@ -3,6 +3,8 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 GLOBAL_INCLUDES += \
 	$(LOCAL_DIR)/include
 
+ifeq ($(SUB_PLATFORM),mt6797)
 MODULE_DEPS += \
 	$(LOCAL_DIR)/gic
+endif
 

--- a/platform/mediatek/mt6735/debug.c
+++ b/platform/mediatek/mt6735/debug.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015 MediaTek Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <debug.h>
+#include <arch/ops.h>
+#include <stdarg.h>
+#include <dev/uart.h>
+#include <platform/mt_uart.h>
+#include <platform.h>
+
+void _dputc(char c)
+{
+    int port = mtk_get_current_uart();
+
+    if (c == '\n') {
+        uart_putc(port, '\r');
+    }
+
+    uart_putc(port, c);
+}
+
+int dgetc(char *c, bool wait)
+{
+    int _c;
+    int port = mtk_get_current_uart();
+
+    if ((_c = uart_getc(port, wait)) < 0) {
+        return -1;
+    }
+
+    *c = _c;
+    return 0;
+}
+
+void platform_halt(platform_halt_action suggested_action, platform_halt_reason reason)
+{
+    arch_disable_ints();
+    for (;;);
+}
+
+uint32_t debug_cycle_count(void)
+{
+    PANIC_UNIMPLEMENTED;
+}
+
+void platform_dputc(char c)
+{
+    if (c == '\n') {
+        _dputc('\r');
+    }
+
+    _dputc(c);
+}
+
+int platform_dgetc(char *c, bool wait)
+{
+    return dgetc(c, wait);
+}

--- a/platform/mediatek/mt6735/include/platform/mt_gpt.h
+++ b/platform/mediatek/mt6735/include/platform/mt_gpt.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015 MediaTek Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef __MT_GPT_H__
+#define __MT_GPT_H__
+#include <platform/mt_typedefs.h>
+#include <sys/types.h>
+#include <stdbool.h>
+
+#define GPT_IRQEN_REG       ((volatile unsigned int*)(APXGPT_BASE))
+#define GPT_IRQSTA_REG      ((volatile unsigned int*)(APXGPT_BASE+0x04))
+#define GPT_IRQACK_REG      ((volatile unsigned int*)(APXGPT_BASE+0x08))
+
+#define GPT4_CON_REG        ((volatile unsigned int*)(APXGPT_BASE+0x40))
+#define GPT4_CLK_REG        ((volatile unsigned int*)(APXGPT_BASE+0x44))
+#define GPT4_DAT_REG        ((volatile unsigned int*)(APXGPT_BASE+0x48))
+
+#define GPT5_CON_REG        ((volatile unsigned int*)(APXGPT_BASE+0x50))
+#define GPT5_CLK_REG        ((volatile unsigned int*)(APXGPT_BASE+0x54))
+#define GPT5_COUNT_REG      ((volatile unsigned int*)(APXGPT_BASE+0x58))
+#define GPT5_COMPARE_REG    ((volatile unsigned int*)(APXGPT_BASE+0x5C))
+
+#define GPT_MODE4_ONE_SHOT (0x00 << 4)
+#define GPT_MODE4_REPEAT   (0x01 << 4)
+#define GPT_MODE4_KEEP_GO  (0x02 << 4)
+#define GPT_MODE4_FREERUN  (0x03 << 4)
+
+#define GPT_CLEAR       2
+
+#define GPT_ENABLE      1
+#define GPT_DISABLE     0
+
+#define GPT_CLK_SYS     (0x0 << 4)
+#define GPT_CLK_RTC     (0x1 << 4)
+
+#define GPT_DIV_BY_1        0
+#define GPT_DIV_BY_2        1
+
+#define GPT4_EN                     0x0001
+#define GPT4_FREERUN                0x0030
+#define GPT4_SYS_CLK                0x0000
+
+#define GPT4_1US_TICK       ((U32)13)           //    1000 / 76.92ns = 13.000
+#define GPT4_1MS_TICK       ((U32)13000)        // 1000000 / 76.92ns = 13000.520
+// 13MHz: 1us = 13.000 ticks
+#define TIME_TO_TICK_US(us) ((us)*GPT4_1US_TICK + ((us)*0 + (1000-1))/1000)
+// 13MHz: 1ms = 13000.520 ticks
+#define TIME_TO_TICK_MS(ms) ((ms)*GPT4_1MS_TICK + ((ms)*520 + (1000-1))/1000)
+
+extern void gpt_init(void);
+
+#endif  /* !__MT_GPT_H__ */

--- a/platform/mediatek/mt6735/include/platform/mt_irq.h
+++ b/platform/mediatek/mt6735/include/platform/mt_irq.h
@@ -1,0 +1,118 @@
+/* Copyright Statement:
+ *
+ * This software/firmware and related documentation ("MediaTek Software") are
+ * protected under relevant copyright laws. The information contained herein
+ * is confidential and proprietary to MediaTek Inc. and/or its licensors.
+ * Without the prior written permission of MediaTek inc. and/or its licensors,
+ * any reproduction, modification, use or disclosure of MediaTek Software,
+ * and information contained herein, in whole or in part, shall be strictly prohibited.
+ */
+/* MediaTek Inc. (C) 2010. All rights reserved.
+ *
+ * BY OPENING THIS FILE, RECEIVER HEREBY UNEQUIVOCALLY ACKNOWLEDGES AND AGREES
+ * THAT THE SOFTWARE/FIRMWARE AND ITS DOCUMENTATIONS ("MEDIATEK SOFTWARE")
+ * RECEIVED FROM MEDIATEK AND/OR ITS REPRESENTATIVES ARE PROVIDED TO RECEIVER ON
+ * AN "AS-IS" BASIS ONLY. MEDIATEK EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE OR NONINFRINGEMENT.
+ * NEITHER DOES MEDIATEK PROVIDE ANY WARRANTY WHATSOEVER WITH RESPECT TO THE
+ * SOFTWARE OF ANY THIRD PARTY WHICH MAY BE USED BY, INCORPORATED IN, OR
+ * SUPPLIED WITH THE MEDIATEK SOFTWARE, AND RECEIVER AGREES TO LOOK ONLY TO SUCH
+ * THIRD PARTY FOR ANY WARRANTY CLAIM RELATING THERETO. RECEIVER EXPRESSLY ACKNOWLEDGES
+ * THAT IT IS RECEIVER'S SOLE RESPONSIBILITY TO OBTAIN FROM ANY THIRD PARTY ALL PROPER LICENSES
+ * CONTAINED IN MEDIATEK SOFTWARE. MEDIATEK SHALL ALSO NOT BE RESPONSIBLE FOR ANY MEDIATEK
+ * SOFTWARE RELEASES MADE TO RECEIVER'S SPECIFICATION OR TO CONFORM TO A PARTICULAR
+ * STANDARD OR OPEN FORUM. RECEIVER'S SOLE AND EXCLUSIVE REMEDY AND MEDIATEK'S ENTIRE AND
+ * CUMULATIVE LIABILITY WITH RESPECT TO THE MEDIATEK SOFTWARE RELEASED HEREUNDER WILL BE,
+ * AT MEDIATEK'S OPTION, TO REVISE OR REPLACE THE MEDIATEK SOFTWARE AT ISSUE,
+ * OR REFUND ANY SOFTWARE LICENSE FEES OR SERVICE CHARGE PAID BY RECEIVER TO
+ * MEDIATEK FOR SUCH MEDIATEK SOFTWARE AT ISSUE.
+ *
+ * The following software/firmware and/or related documentation ("MediaTek Software")
+ * have been modified by MediaTek Inc. All revisions are subject to any receiver's
+ * applicable license agreements with MediaTek Inc.
+ */
+
+#ifndef __MT_IRQ_H__
+#define __MT_IRQ_H__
+
+#define GIC_CPU_CTRL			0x00
+#define GIC_CPU_PRIMASK			0x04
+#define GIC_CPU_BINPOINT		0x08
+#define GIC_CPU_INTACK			0x0c
+#define GIC_CPU_EOI			0x10
+#define GIC_CPU_RUNNINGPRI		0x14
+#define GIC_CPU_HIGHPRI			0x18
+
+#define GIC_DIST_CTRL			0x000
+#define GIC_DIST_CTR			0x004
+#define GIC_DIST_ENABLE_SET		0x100
+#define GIC_DIST_ENABLE_CLEAR		0x180
+#define GIC_DIST_PENDING_SET		0x200
+#define GIC_DIST_PENDING_CLEAR		0x280
+#define GIC_DIST_ACTIVE_BIT		0x300
+#define GIC_DIST_PRI			0x400
+#define GIC_DIST_TARGET			0x800
+#define GIC_DIST_CONFIG			0xc00
+#define GIC_DIST_SOFTINT		0xf00
+#define GIC_DIST_ICDISR  		0x80
+enum {IRQ_MASK_HEADER = 0xF1F1F1F1, IRQ_MASK_FOOTER = 0xF2F2F2F2};
+
+struct mtk_irq_mask
+{
+    unsigned int header;   /* for error checking */
+    unsigned int mask0;
+    unsigned int mask1;
+    unsigned int mask2;
+    unsigned int mask3;
+    unsigned int mask4;
+    unsigned int mask5;
+    unsigned int mask6;
+    unsigned int mask7;
+    unsigned int footer;   /* for error checking */
+};
+
+
+/*
+ * Define hadware registers.
+ */
+
+/*
+ * Define IRQ code.
+ */
+
+#define GIC_PRIVATE_SIGNALS (32)
+
+#define GIC_PPI_OFFSET          (27)
+#define GIC_PPI_GLOBAL_TIMER    (GIC_PPI_OFFSET + 0)
+#define GIC_PPI_LEGACY_FIQ      (GIC_PPI_OFFSET + 1)
+#define GIC_PPI_PRIVATE_TIMER   (GIC_PPI_OFFSET + 2)
+#define GIC_PPI_WATCHDOG_TIMER  (GIC_PPI_OFFSET + 3)
+#define GIC_PPI_LEGACY_IRQ      (GIC_PPI_OFFSET + 4)
+
+
+#define MT_GPT_IRQ_ID   184
+#define MT_USB0_IRQ_ID  104
+#define MT_MSDC0_IRQ_ID 111
+#define MT_MSDC1_IRQ_ID 112
+
+#define MT_NR_PPI   (5)
+#define MT_NR_SPI   (221)
+#define NR_IRQ_LINE  (GIC_PPI_OFFSET + MT_NR_PPI + MT_NR_SPI)    // 5 PPIs and 224 SPIs
+
+#define MT65xx_EDGE_SENSITIVE 0
+#define MT65xx_LEVEL_SENSITIVE 1
+
+#define MT65xx_POLARITY_LOW   0
+#define MT65xx_POLARITY_HIGH  1
+
+
+int mt_irq_mask_all(struct mtk_irq_mask *mask); //(This is ONLY used for the sleep driver)
+int mt_irq_mask_restore(struct mtk_irq_mask *mask); //(This is ONLY used for the sleep driver)
+void mt_irq_set_sens(unsigned int irq, unsigned int sens);
+void mt_irq_set_polarity(unsigned int irq, unsigned int polarity);
+int mt_irq_mask_restore(struct mtk_irq_mask *mask);
+void mt_irq_unmask(unsigned int irq);
+void mt_irq_ack(unsigned int irq);
+
+void platform_init_interrupts(void);

--- a/platform/mediatek/mt6735/include/platform/mt_reg_base.h
+++ b/platform/mediatek/mt6735/include/platform/mt_reg_base.h
@@ -1,0 +1,640 @@
+/*
+ * Copyright (c) 2015 MediaTek Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * This file comes from cross-reference of
+ *   http://git.huayusoft.com/tomsu/AP7350_MDK-kernel
+ * and
+ *   https://github.com/alexgoussev/AP7350_MDK-kernel
+ */
+#ifndef __MT_REG_BASE_H__
+#define __MT_REG_BASE_H__
+
+#define BOOTROM_BASE    (0x00000000)
+#define BOOTSRAM_BASE   (0x00100000)
+#define IO_PHYS         (0x10000000)
+
+// APB Module cksys
+#define CKSYS_BASE      (0x10210000)
+#define TOPCKGEN_BASE   (0x10210000)
+
+// APB Module infracfg_ao
+#define INFRACFG_AO_BASE (0x10000000)
+
+#define IOCFG_L_BASE    (0x10211000)
+#define IOCFG_B_BASE    (0x10211400)
+#define IOCFG_R_BASE    (0x10211800)
+#define IOCFG_T_BASE    (0x10211C00)
+
+// APB Module pericfg
+#define PERICFG_BASE    (0x10002000)
+
+// APB Module dramc
+#define DRAMC0_BASE     (0x10214000)
+
+// APB Module gpio
+#define GPIO_BASE       (0x10211000)
+
+// APB Module sleep
+#define SLEEP_BASE      (0x10006000)
+
+// APB Module toprgu
+#define TOPRGU_BASE     (0x10212000)
+
+// APB Module apxgpt
+#define APXGPT_BASE     (0x10004000)
+
+// APB Module rsvd
+#define RSVD_BASE       (0x10009000)
+
+// APB Module sej
+#define SEJ_BASE        (0x10008000)
+
+// APB Module ap_cirq_eint
+#define APIRQ_BASE      (0x10005000)
+
+// APB Module smi
+//#define SMI_COMMON_AO_BASE (0x1000C000)
+
+// APB Module pmic_wrap
+#define PWRAP_BASE      (0x10001000)
+
+// APB Module device_apc_ao
+#define DEVAPC_AO_BASE  (0x10007000)
+
+// APB Module ddrphy
+#define DDRPHY_BASE     (0x10213000)
+
+// APB Module kp
+#define KP_BASE         (0x10003000)
+
+// APB Module DRAMC1_BASE
+//#define DRAMC1_BASE (0x10011000)
+
+// APB Module DDRPHY1_BASE
+//#define DDRPHY1_BASE (0x10012000)
+
+// APB Module md32
+//#define MD32_BASE (0x10058000)
+
+// APB Module dbgapb
+#define DBGAPB_BASE     (0x10400000)
+
+// APB Module mcucfg
+#define MCUCFG_BASE     (0x10200000)
+
+// APB Module ca7mcucfg
+#define CA7MCUCFG_BASE  (0x10200400)
+
+// APB Module infracfg
+#define INFRACFG_BASE   (0x10201000)
+
+// APB Module sramrom
+#define SRAMROM_BASE    (0x10202000)
+
+// APB Module emi
+#define EMI_BASE        (0x10203000)
+
+// APB Module sys_cirq
+#define SYS_CIRQ_BASE   (0x10204000)
+
+// APB Module mm_iommu
+#define M4U_BASE        (0x10205000)
+
+// APB Module efusec
+#define EFUSEC_BASE     (0x10206000)
+
+// APB Module device_apc
+#define DEVAPC_BASE     (0x10207000)
+
+// APB Module bus_dbg_tracker_cfg
+#define BUS_DBG_BASE    (0x10208000)
+
+// APB Module apmixed
+//#define APMIXED_BASE (0x10209000)
+
+// APB Module fhctl
+//#define FHCTL_BASE (0x1000cF00)
+
+// APB Module ccif
+//#define AP_CCIF0_BASE (0x1020A000)
+
+// APB Module ccif
+//#define MD_CCIF0_BASE (0xA020B000)
+
+// APB Module gpio1
+//#define GPIO1_BASE (0x1020C000)
+
+// APB Module infra_mbist
+#define INFRA_MBIST_BASE (0x1020D000)
+
+// APB Module dramc_conf_nao
+#define DRAMC_NAO_BASE  (0x1020E000)
+
+// APB Module trng
+#define TRNG_BASE       (0x1020F000)
+
+// APB Module gcpu
+#define GCPU_BASE       (0x10216000)
+
+// APB Module gcpu_ns
+//#define GCPU_NS_BASE (0x10211000)
+
+// APB Module gcpu_ns
+#define GCE_BASE        (0x10217000)
+
+// APB Module dramc_conf_nao
+//#define DRAMC1_NAO_BASE (0x10213000)
+
+// APB Module perisys_iommu
+//#define PERISYS_IOMMU_BASE (0x10214000)
+
+// APB Module mipi_tx_config
+//#define MIPI_TX0_BASE (0x10215000)
+//#define MIPI_TX1_BASE (0x1021e000)
+
+// MIPI TX Config
+//#define MIPI_TX_CONFIG_BASE (0x10012000)
+
+// APB Module mipi_rx_ana_csi0
+#define MIPI_RX_ANA_CSI0_BASE (0x10215000)
+
+// APB Module mipi_rx_ana_csi1
+#define MIPI_RX_ANA_CSI1_BASE (MIPI_RX_ANA_CSI0_BASE)
+
+// APB Module mipi_rx_ana_csi2
+//#define MIPI_RX_ANA_CSI2_BASE (0x10219000)
+
+// APB Module ca9
+#define CA9_BASE        (0x10220000)
+
+// APB Module cq_dma
+//#define CQ_DMA_BASE (0x10212c00)
+
+// APB Module ap_dma
+#define AP_DMA_BASE     (0x11000000)
+
+// APB Module auxadc
+#define AUXADC_BASE     (0x11001000)
+
+// APB Module uart
+#define AP_UART0_BASE   (0x11002000)
+
+// APB Module uart
+#define AP_UART1_BASE   (0x11003000)
+
+// APB Module uart
+#define AP_UART2_BASE   (0x11004000)
+
+// APB Module uart
+#define AP_UART3_BASE   (0x11005000)
+
+// APB Module uart - WARNNING conflict with NFI_BASE (0x1100D000)
+#define AP_UART4_BASE   (0x1100D000)
+
+// APB Module pwm
+#define PWM_BASE        (0x11006000)
+
+// APB Module i2c
+#define I2C0_BASE       (0x11007000)
+
+// APB Module i2c
+#define I2C1_BASE       (0x11008000)
+
+// APB Module i2c
+#define I2C2_BASE       (0x11009000)
+
+// APB Module spi
+#define SPI1_BASE       (0x1100A000)
+
+// APB Module therm_ctrl
+#define THERM_CTRL_BASE (0x1100B000)
+
+// APB Module btif
+#define BTIF_BASE       (0x1100C000)
+
+// APB Module nfi
+#define NFI_BASE        (0x1100D000)
+
+// APB Module nfiecc
+#define NFIECC_BASE     (0x1100E000)
+
+// APB Module nli_arb
+//#define NLI_ARB_BASE (0x1100F000)
+
+// APB Module i2c
+//#define I2C3_BASE (0x11010000)
+
+// APB Module i2c
+//#define I2C4_BASE (0x11011000)
+
+// APB Module usb2
+#define USB_BASE        (0x11200000)
+
+// APB Module usb_sif
+#define USBSIF_BASE     (0x11210000)
+
+// APB Module audio
+#define AUDIO_BASE      (0x11220000)
+
+// APB Module msdc
+#define MSDC0_BASE      (0x11230000)
+
+// APB Module msdc
+#define MSDC1_BASE      (0x11240000)
+
+// APB Module msdc
+#define MSDC2_BASE      (0x11250000)
+
+// APB Module msdc
+#define MSDC3_BASE      (0x11260000)
+
+// APB Module USB_1p
+//#define ICUSB_BASE (0x11270000)
+
+// APB Module ssusb_top
+//#define USB3_BASE (0x11270000)
+
+// APB Module ssusb_top_sif
+//#define USB3_SIF_BASE (0x11280000)
+
+// APB Module ssusb_top_sif2
+//#define USB3_SIF2_BASE (0x11290000)
+
+// APB Module mfg_top
+//#define MFGCFG_BASE (0x13FFF000)
+
+// APB Module han
+//#define HAN_BASE (0x13000000)
+
+// APB Module mmsys_config
+#define MMSYS_CONFIG_BASE (0x14000000)
+
+// APB Module mdp_rdma
+#define MDP_RDMA0_BASE  (0x14001000)
+
+// APB Module mdp_rdma
+//#define MDP_RDMA1_BASE (0x14002000)
+
+// APB Module mdp_rsz
+#define MDP_RSZ0_BASE   (0x14003000)
+
+// APB Module mdp_rsz
+#define MDP_RSZ1_BASE   (0x14004000)
+
+// APB Module mdp_rsz
+//#define MDP_RSZ2_BASE (0x14005000)
+
+// APB Module disp_wdma
+#define MDP_WDMA_BASE   (0x14004000)
+
+// APB Module mdp_wrot
+#define MDP_WROT0_BASE  (0x14005000)
+
+// APB Module mdp_wrot
+//#define MDP_WROT1_BASE (0x14008000)
+
+// APB Module mdp_tdshp
+#define MDP_TDSHP0_BASE (0x14006000)
+
+// APB Module mdp_tdshp
+//#define MDP_TDSHP1_BASE (0x1400a000)
+
+// APB Module mdp_tdshp
+//#define MDP_CROP_BASE (0x1400b000)
+
+#if defined(MACH_TYPE_MT6735)
+// DISPSYS
+// APB Module ovl
+#define OVL0_BASE       (0x14007000)
+
+// APB Module ovl
+#define OVL1_BASE       (0)
+
+// APB Module disp_rdma
+#define DISP_RDMA0_BASE (0x14008000)
+
+// APB Module disp_rdma
+#define DISP_RDMA1_BASE (0x14009000)
+
+// APB Module disp_wdma
+#define DISP_WDMA0_BASE (0x1400A000)
+
+// PQ and AAL
+// APB Module disp_color_config
+#define COLOR0_BASE     (0x1400B000)
+#define CCORR_BASE      (0x1400C000)
+
+// APB Module disp_aal
+#define DISP_AAL_BASE   (0x1400D000)
+
+// APB Module disp_gamma
+#define DISP_GAMMA_BASE (0x1400E000)
+
+// APB Module dsi
+#define DSI0_BASE       (0x14011000)
+
+// APB DITHER dsi
+#define DITHER_BASE     (0x1400F000)
+
+// APB Module disp_dpi
+#define DPI_BASE        (0x14012000)
+
+// APB Module disp_pwm
+#define DISP_PWM0_BASE  (0x1100E000)
+
+// APB Module disp_mutex
+#define MM_MUTEX_BASE   (0x14014000)
+
+// APB Module smi_larb
+#define SMI_LARB0_BASE  (0x14015000)
+
+// APB Module smi
+#define SMI_COMMON_BASE (0x14016000)
+
+// APB Module mipi_tx_config
+#define MIPI_TX0_BASE   (0x14017000)
+
+// APB Module od
+#define OD_BASE         (0)
+
+#elif defined(MACH_TYPE_MT6735M)
+// APB Module ovl
+#define OVL0_BASE       (0x14007000)
+
+// APB Module ovl
+#define OVL1_BASE       (0)
+
+// APB Module disp_rdma
+#define DISP_RDMA0_BASE (0x14009000)
+
+// APB Module disp_rdma
+#define DISP_RDMA1_BASE (0x0)
+
+// APB Module disp_wdma
+#define DISP_WDMA0_BASE (0x1400B000)
+
+// APB Module disp_color_config
+#define COLOR0_BASE     (0x1400C000)
+#define CCORR_BASE      (0x1400D000)
+// APB Module disp_aal
+#define DISP_AAL_BASE   (0x1400E000)
+
+// APB Module disp_gamma
+#define DISP_GAMMA_BASE (0x1400F000)
+
+// APB Module dsi
+#define DSI0_BASE       (0x14012000)
+
+// APB DITHER dsi
+#define DITHER_BASE     (0x14010000)
+
+// APB Module disp_dpi
+#define DPI_BASE        (0x14013000)
+
+// APB Module disp_pwm
+#define DISP_PWM0_BASE  (0x1100E000)
+
+// APB Module disp_mutex
+#define MM_MUTEX_BASE   (0x14015000)
+
+// APB Module smi_larb
+#define SMI_LARB0_BASE  (0x14016000)
+
+// APB Module smi
+#define SMI_COMMON_BASE (0x14017000)
+
+// APB Module mipi_tx_config
+#define MIPI_TX0_BASE   (0x14018000)
+
+// APB Module od
+#define OD_BASE         (0)
+
+#elif defined(MACH_TYPE_MT6753)
+
+// APB Module ovl
+#define OVL0_BASE       (0x14007000)
+
+// APB Module ovl
+#define OVL1_BASE       (0)
+
+// APB Module disp_rdma
+#define DISP_RDMA0_BASE (0x14009000)
+
+// APB Module disp_rdma
+#define DISP_RDMA1_BASE (0x1400A000)
+
+// APB Module disp_wdma
+#define DISP_WDMA0_BASE (0x1400B000)
+
+// APB Module disp_color_config
+#define COLOR0_BASE     (0x1400C000)
+#define CCORR_BASE      (0x1400D000)
+// APB Module disp_aal
+#define DISP_AAL_BASE   (0x1400E000)
+
+// APB Module disp_gamma
+#define DISP_GAMMA_BASE (0x1400F000)
+
+// APB Module dsi
+#define DSI0_BASE       (0x14013000)
+
+// APB DITHER dsi
+#define DITHER_BASE     (0x14010000)
+
+// APB Module disp_dpi
+#define DPI_BASE        (0x14014000)
+
+// APB Module disp_pwm
+#define DISP_PWM0_BASE  (0x1100E000)
+
+// APB Module disp_mutex
+#define MM_MUTEX_BASE   (0x14015000)
+
+// APB Module smi_larb
+#define SMI_LARB0_BASE  (0x14016000)
+
+// APB Module smi
+#define SMI_COMMON_BASE (0x14017000)
+
+// APB Module mipi_tx_config
+#define MIPI_TX0_BASE   (0x14018000)
+
+// APB Module od
+#define OD_BASE         (0x14012000)
+
+#endif
+
+// APB Module smi_larb
+//#define SMI_LARB2_BASE (0x15001000)
+
+// APB Module fake_eng
+//#define FAKE_ENG_BASE (0x15002000)
+
+// APB Module imgsys
+//#define IMGSYS_BASE (0x15000000)
+
+// APB Module cam1
+//#define CAM1_BASE (0x15004000)
+
+// APB Module cam2
+//#define CAM2_BASE (0x15005000)
+
+// APB Module cam3
+//#define CAM3_BASE (0x15006000)
+
+// APB Module cam4
+//#define CAM4_BASE (0x15007000)
+
+// APB Module camsv
+//#define CAMSV_BASE (0x15009000)
+
+// APB Module camsv_top
+//#define CAMSV_TOP_BASE (0x15009000)
+
+// APB Module csi2
+//#define CSI2_BASE (0x15008000)
+
+// APB Module seninf
+//#define SENINF_BASE (0x15008000)
+
+// APB Module seninf_tg
+//#define SENINF_TG_BASE (0x15008000)
+
+// APB Module seninf_top
+//#define SENINF_TOP_BASE (0x15008000)
+
+// APB Module seninf_mux
+//#define SENINF_MUX_BASE (0x15008000)
+
+// APB Module mipi_rx_config
+//#define MIPI_RX_CONFIG_BASE (0x15008000)
+
+// APB Module scam
+//#define SCAM_BASE (0x15008C00)
+
+// APB Module ncsi2
+//#define NCSI2_BASE (0x15008000)
+
+// APB Module ccir656
+//#define CCIR656_BASE (0x15008000)
+
+// APB Module n3d_ctl
+//#define N3D_CTL_BASE (0x15008000)
+
+// APB Module fdvt
+//#define FDVT_BASE (0x1500B000)
+
+// APB Module vdecsys_config
+//#define VDEC_GCON_BASE (0x16000000)
+
+// APB Module smi_larb
+//#define SMI_LARB1_BASE (0x16010000)
+
+// APB Module vdtop
+//#define VDEC_BASE (0x16020000)
+
+// APB Module vdtop
+//#define VDTOP_BASE (0x16020000)
+
+// APB Module vld
+//#define VLD_BASE (0x16021000)
+
+// APB Module vld_top
+//#define VLD_TOP_BASE (0x16021800)
+
+// APB Module mc
+//#define MC_BASE (0x16022000)
+
+// APB Module avc_vld
+//#define AVC_VLD_BASE (0x16023000)
+
+// APB Module avc_mv
+//#define AVC_MV_BASE (0x16024000)
+
+// APB Module vdec_pp
+//#define VDEC_PP_BASE (0x16025000)
+
+// APB Module hevc_vld
+//#define HEVC_VLD_BASE (0x16028000)
+
+// APB Module vp8_vld
+//#define VP8_VLD_BASE (0x16026800)
+
+// APB Module vp6
+//#define VP6_BASE (0x16027000)
+
+// APB Module vld2
+//#define VLD2_BASE (0x16027800)
+
+// APB Module mc_vmmu
+//#define MC_VMMU_BASE (0x16028000)
+
+// APB Module pp_vmmu
+//#define PP_VMMU_BASE (0x16029000)
+
+// APB Module mjc_config
+//#define MJC_CONFIG_BASE (0x17000000)
+
+// APB Module mjc_top
+//#define MJC_TOP_BASE (0x17001000)
+
+// APB Module smi_larb
+//#define SMI_LARB4_BASE (0x17002000)
+
+// APB Module venc_config
+//#define VENC_GCON_BASE (0x18000000)
+
+// APB Module smi_larb
+//#define SMI_LARB3_BASE (0x18001000)
+
+// APB Module venc
+//#define VENC_BASE (0x18002000)
+
+// APB Module jpgenc
+//#define JPGENC_BASE (0x18003000)
+
+// APB Module jpgdec
+//#define JPGDEC_BASE (0x18004000)
+
+// APB Module audiosys
+#define AUDIOSYS_BASE   (AUDIO_BASE)
+
+// rtc
+#define RTC_BASE (0x4000)
+
+//Marcos add for early porting
+//#define SYSRAM_BASE (0x19000000)
+#define GIC_DIST_BASE   (CA9_BASE + 0x1000)
+//#define GIC_REDIS_BASE (0x19200000)
+#define GIC_CPU_BASE    (CA9_BASE + 0x2000)
+
+/* hardware version register */
+#define VER_BASE        (0x08000000)
+#define APHW_CODE       (VER_BASE)
+#define APHW_SUBCODE    (VER_BASE + 0x04)
+#define APHW_VER        (VER_BASE + 0x08)
+#define APSW_VER        (VER_BASE + 0x0C)
+
+////////////////////////////////////////
+
+#endif /* !__MT_REG_BASE_H__ */

--- a/platform/mediatek/mt6735/include/platform/mt_typedefs.h
+++ b/platform/mediatek/mt6735/include/platform/mt_typedefs.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2015 MediaTek Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* ------------
+ *   Type definition.
+ */
+
+#ifndef __MT_TYPEDEFS_H__
+#define __MT_TYPEDEFS_H__
+
+
+/*==== CONSTANTS ==================================================*/
+
+#define IMPORT  EXTERN
+#ifndef __cplusplus
+#define EXTERN  extern
+#else
+#define EXTERN  extern "C"
+#endif
+#define LOCAL     static
+#define GLOBAL
+#define EXPORT    GLOBAL
+
+
+#define EQ        ==
+#define NEQ       !=
+#define AND       &&
+#define OR        ||
+#define XOR(A,B)  ((!(A) AND (B)) OR ((A) AND !(B)))
+
+#ifndef FALSE
+#define FALSE   0
+#endif
+
+#ifndef TRUE
+#define TRUE    1
+#endif
+
+#ifndef NULL
+#define NULL    0
+#endif
+
+#ifndef BOOL
+typedef unsigned char  BOOL;
+#endif
+
+typedef volatile unsigned char  *UINT8P;
+typedef volatile unsigned short *UINT16P;
+typedef volatile unsigned int   *UINT32P;
+
+
+typedef unsigned char   UINT8;
+typedef unsigned short  UINT16;
+typedef unsigned int    UINT32;
+typedef unsigned short  USHORT;
+typedef signed char     INT8;
+typedef signed short    INT16;
+typedef signed int      INT32;
+typedef signed int      DWORD;
+typedef void            VOID;
+typedef unsigned char   BYTE;
+typedef float           FLOAT;
+
+
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef unsigned long long u64;
+
+typedef unsigned long long  U64;
+typedef unsigned int        U32;
+typedef unsigned short      U16;
+typedef unsigned char       U8;
+
+typedef signed char         s8;
+typedef signed short        s16;
+typedef signed int          s32;
+typedef signed long long    s64;
+
+typedef signed char         S8;
+typedef signed short        S16;
+typedef signed int          S32;
+typedef signed long long    S64;
+
+
+/*==== EXPORT =====================================================*/
+
+#define MAXIMUM(A,B)       (((A)>(B))?(A):(B))
+#define MINIMUM(A,B)       (((A)<(B))?(A):(B))
+
+#define READ_REGISTER_UINT32(reg) \
+    (*(volatile unsigned int * const)(reg))
+
+#define WRITE_REGISTER_UINT32(reg, val) \
+    (*(volatile unsigned int * const)(reg)) = (val)
+
+#define READ_REGISTER_UINT16(reg) \
+    (*(volatile unsigned short * const)(reg))
+
+#define WRITE_REGISTER_UINT16(reg, val) \
+    (*(volatile unsigned short * const)(reg)) = (val)
+
+#define READ_REGISTER_UINT8(reg) \
+    (*(volatile unsigned char * const)(reg))
+
+#define WRITE_REGISTER_UINT8(reg, val) \
+    (*(volatile unsigned char * const)(reg)) = (val)
+
+#define INREG8(x)           READ_REGISTER_UINT8((unsigned char *)(x))
+#define OUTREG8(x, y)       WRITE_REGISTER_UINT8((unsigned char *)(x), (unsigned char)(y))
+#define SETREG8(x, y)       OUTREG8(x, INREG8(x)|(y))
+#define CLRREG8(x, y)       OUTREG8(x, INREG8(x)&~(y))
+#define MASKREG8(x, y, z)   OUTREG8(x, (INREG8(x)&~(y))|(z))
+
+#define INREG16(x)          READ_REGISTER_UINT16((unsigned short *)(x))
+#define OUTREG16(x, y)      WRITE_REGISTER_UINT16((unsigned short *)(x),(unsigned short)(y))
+#define SETREG16(x, y)      OUTREG16(x, INREG16(x)|(y))
+#define CLRREG16(x, y)      OUTREG16(x, INREG16(x)&~(y))
+#define MASKREG16(x, y, z)  OUTREG16(x, (INREG16(x)&~(y))|(z))
+
+#define INREG32(x)          READ_REGISTER_UINT32((unsigned int *)(x))
+#define OUTREG32(x, y)      WRITE_REGISTER_UINT32((unsigned int *)(x), (unsigned int )(y))
+#define SETREG32(x, y)      OUTREG32(x, INREG32(x)|(y))
+#define CLRREG32(x, y)      OUTREG32(x, INREG32(x)&~(y))
+#define MASKREG32(x, y, z)  OUTREG32(x, (INREG32(x)&~(y))|(z))
+
+
+#define DRV_Reg8(addr)              INREG8(addr)
+#define DRV_WriteReg8(addr, data)   OUTREG8(addr, data)
+#define DRV_SetReg8(addr, data)     SETREG8(addr, data)
+#define DRV_ClrReg8(addr, data)     CLRREG8(addr, data)
+
+#define DRV_Reg16(addr)             INREG16(addr)
+#define DRV_WriteReg16(addr, data)  OUTREG16(addr, data)
+#define DRV_SetReg16(addr, data)    SETREG16(addr, data)
+#define DRV_ClrReg16(addr, data)    CLRREG16(addr, data)
+
+#define DRV_Reg32(addr)             INREG32(addr)
+#define DRV_WriteReg32(addr, data)  OUTREG32(addr, data)
+#define DRV_SetReg32(addr, data)    SETREG32(addr, data)
+#define DRV_ClrReg32(addr, data)    CLRREG32(addr, data)
+
+#endif /* !__MT_TYPEDEFS_H__ */

--- a/platform/mediatek/mt6735/include/platform/mt_uart.h
+++ b/platform/mediatek/mt6735/include/platform/mt_uart.h
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2015 MediaTek Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef ___MTK_UART_H__
+#define ___MTK_UART_H__
+
+#include <platform/mt_reg_base.h>
+
+typedef enum {
+    UART1 = AP_UART0_BASE,
+    UART2 = AP_UART1_BASE,
+    UART3 = AP_UART2_BASE,
+    UART4 = AP_UART3_BASE
+} MTK_UART;
+
+#define UART_SRC_CLK            26000000
+
+#define CONFIG_BAUDRATE         921600
+
+#define UART_BASE(uart)                   (uart)
+#define UART_RBR(uart)                    (UART_BASE(uart)+0x0)  /* Read only */
+#define UART_THR(uart)                    (UART_BASE(uart)+0x0)  /* Write only */
+#define UART_IER(uart)                    (UART_BASE(uart)+0x4)
+#define UART_IIR(uart)                    (UART_BASE(uart)+0x8)  /* Read only */
+#define UART_FCR(uart)                    (UART_BASE(uart)+0x8)  /* Write only */
+#define UART_LCR(uart)                    (UART_BASE(uart)+0xc)
+#define UART_MCR(uart)                    (UART_BASE(uart)+0x10)
+#define UART_LSR(uart)                    (UART_BASE(uart)+0x14)
+#define UART_MSR(uart)                    (UART_BASE(uart)+0x18)
+#define UART_SCR(uart)                    (UART_BASE(uart)+0x1c)
+#define UART_DLL(uart)                    (UART_BASE(uart)+0x0)  /* Only when LCR.DLAB = 1 */
+#define UART_DLH(uart)                    (UART_BASE(uart)+0x4)  /* Only when LCR.DLAB = 1 */
+#define UART_EFR(uart)                    (UART_BASE(uart)+0x8)  /* Only when LCR = 0xbf */
+#define UART_XON1(uart)                   (UART_BASE(uart)+0x10) /* Only when LCR = 0xbf */
+#define UART_XON2(uart)                   (UART_BASE(uart)+0x14) /* Only when LCR = 0xbf */
+#define UART_XOFF1(uart)                  (UART_BASE(uart)+0x18) /* Only when LCR = 0xbf */
+#define UART_XOFF2(uart)                  (UART_BASE(uart)+0x1c) /* Only when LCR = 0xbf */
+#define UART_AUTOBAUD_EN(uart)            (UART_BASE(uart)+0x20)
+#define UART_HIGHSPEED(uart)              (UART_BASE(uart)+0x24)
+#define UART_SAMPLE_COUNT(uart)           (UART_BASE(uart)+0x28)
+#define UART_SAMPLE_POINT(uart)           (UART_BASE(uart)+0x2c)
+#define UART_AUTOBAUD_REG(uart)           (UART_BASE(uart)+0x30)
+#define UART_RATE_FIX_AD(uart)            (UART_BASE(uart)+0x34)
+#define UART_AUTOBAUD_SAMPLE(uart)        (UART_BASE(uart)+0x38)
+#define UART_GUARD(uart)                  (UART_BASE(uart)+0x3c)
+#define UART_ESCAPE_DAT(uart)             (UART_BASE(uart)+0x40)
+#define UART_ESCAPE_EN(uart)              (UART_BASE(uart)+0x44)
+#define UART_SLEEP_EN(uart)               (UART_BASE(uart)+0x48)
+#define UART_VFIFO_EN(uart)               (UART_BASE(uart)+0x4c)
+#define UART_RXTRI_AD(uart)               (UART_BASE(uart)+0x50)
+
+#define UART_FIFO_SIZE              (16)
+#define IO_OFFSET                   (0)
+
+
+/* IER */
+#define UART_IER_ERBFI              (1 << 0) /* RX buffer conatins data int. */
+#define UART_IER_ETBEI              (1 << 1) /* TX FIFO threshold trigger int. */
+#define UART_IER_ELSI               (1 << 2) /* BE, FE, PE, or OE int. */
+#define UART_IER_EDSSI              (1 << 3) /* CTS change (DCTS) int. */
+#define UART_IER_XOFFI              (1 << 5)
+#define UART_IER_RTSI               (1 << 6)
+#define UART_IER_CTSI               (1 << 7)
+
+#define UART_IER_ALL_INTS          (UART_IER_ERBFI|UART_IER_ETBEI|UART_IER_ELSI|\
+                                    UART_IER_EDSSI|UART_IER_XOFFI|UART_IER_RTSI|\
+                                    UART_IER_CTSI)
+#define UART_IER_HW_NORMALINTS     (UART_IER_ERBFI|UART_IER_ELSI|UART_IER_EDSSI)
+#define UART_IER_HW_ALLINTS        (UART_IER_ERBFI|UART_IER_ETBEI| \
+                                    UART_IER_ELSI|UART_IER_EDSSI)
+
+/* FCR */
+#define UART_FCR_FIFOE              (1 << 0)
+#define UART_FCR_CLRR               (1 << 1)
+#define UART_FCR_CLRT               (1 << 2)
+#define UART_FCR_DMA1               (1 << 3)
+#define UART_FCR_RXFIFO_1B_TRI      (0 << 6)
+#define UART_FCR_RXFIFO_6B_TRI      (1 << 6)
+#define UART_FCR_RXFIFO_12B_TRI     (2 << 6)
+#define UART_FCR_RXFIFO_RX_TRI      (3 << 6)
+#define UART_FCR_TXFIFO_1B_TRI      (0 << 4)
+#define UART_FCR_TXFIFO_4B_TRI      (1 << 4)
+#define UART_FCR_TXFIFO_8B_TRI      (2 << 4)
+#define UART_FCR_TXFIFO_14B_TRI     (3 << 4)
+
+#define UART_FCR_FIFO_INIT          (UART_FCR_FIFOE|UART_FCR_CLRR|UART_FCR_CLRT)
+#define UART_FCR_NORMAL             (UART_FCR_FIFO_INIT | \
+                                     UART_FCR_TXFIFO_4B_TRI| \
+                                     UART_FCR_RXFIFO_12B_TRI)
+
+/* LCR */
+#define UART_LCR_BREAK              (1 << 6)
+#define UART_LCR_DLAB               (1 << 7)
+
+#define UART_WLS_5                  (0 << 0)
+#define UART_WLS_6                  (1 << 0)
+#define UART_WLS_7                  (2 << 0)
+#define UART_WLS_8                  (3 << 0)
+#define UART_WLS_MASK               (3 << 0)
+
+#define UART_1_STOP                 (0 << 2)
+#define UART_2_STOP                 (1 << 2)
+#define UART_1_5_STOP               (1 << 2)    /* Only when WLS=5 */
+#define UART_STOP_MASK              (1 << 2)
+
+#define UART_NONE_PARITY            (0 << 3)
+#define UART_ODD_PARITY             (0x1 << 3)
+#define UART_EVEN_PARITY            (0x3 << 3)
+#define UART_MARK_PARITY            (0x5 << 3)
+#define UART_SPACE_PARITY           (0x7 << 3)
+#define UART_PARITY_MASK            (0x7 << 3)
+
+/* MCR */
+#define UART_MCR_DTR                (1 << 0)
+#define UART_MCR_RTS                (1 << 1)
+#define UART_MCR_OUT1               (1 << 2)
+#define UART_MCR_OUT2               (1 << 3)
+#define UART_MCR_LOOP               (1 << 4)
+#define UART_MCR_XOFF               (1 << 7)    /* read only */
+#define UART_MCR_NORMAL             (UART_MCR_DTR|UART_MCR_RTS)
+
+/* LSR */
+#define UART_LSR_DR                 (1 << 0)
+#define UART_LSR_OE                 (1 << 1)
+#define UART_LSR_PE                 (1 << 2)
+#define UART_LSR_FE                 (1 << 3)
+#define UART_LSR_BI                 (1 << 4)
+#define UART_LSR_THRE               (1 << 5)
+#define UART_LSR_TEMT               (1 << 6)
+#define UART_LSR_FIFOERR            (1 << 7)
+
+/* MSR */
+#define UART_MSR_DCTS               (1 << 0)
+#define UART_MSR_DDSR               (1 << 1)
+#define UART_MSR_TERI               (1 << 2)
+#define UART_MSR_DDCD               (1 << 3)
+#define UART_MSR_CTS                (1 << 4)
+#define UART_MSR_DSR                (1 << 5)
+#define UART_MSR_RI                 (1 << 6)
+#define UART_MSR_DCD                (1 << 7)
+
+/* EFR */
+#define UART_EFR_EN                 (1 << 4)
+#define UART_EFR_AUTO_RTS           (1 << 6)
+#define UART_EFR_AUTO_CTS           (1 << 7)
+#define UART_EFR_SW_CTRL_MASK       (0xf << 0)
+
+#define UART_EFR_NO_SW_CTRL         (0)
+#define UART_EFR_NO_FLOW_CTRL       (0)
+#define UART_EFR_AUTO_RTSCTS        (UART_EFR_AUTO_RTS|UART_EFR_AUTO_CTS)
+#define UART_EFR_XON1_XOFF1         (0xa) /* TX/RX XON1/XOFF1 flow control */
+#define UART_EFR_XON2_XOFF2         (0x5) /* TX/RX XON2/XOFF2 flow control */
+#define UART_EFR_XON12_XOFF12       (0xf) /* TX/RX XON1,2/XOFF1,2 flow
+control */
+
+#define UART_EFR_XON1_XOFF1_MASK    (0xa)
+#define UART_EFR_XON2_XOFF2_MASK    (0x5)
+
+/* IIR (Read Only) */
+#define UART_IIR_NO_INT_PENDING     (0x01)
+#define UART_IIR_RLS                (0x06) /* Receiver Line Status */
+#define UART_IIR_RDA                (0x04) /* Receive Data Available */
+#define UART_IIR_CTI                (0x0C) /* Character Timeout Indicator */
+#define UART_IIR_THRE               (0x02) /* Transmit Holding Register Empty
+*/
+#define UART_IIR_MS                 (0x00) /* Check Modem Status Register */
+#define UART_IIR_SW_FLOW_CTRL       (0x10) /* Receive XOFF characters */
+#define UART_IIR_HW_FLOW_CTRL       (0x20) /* CTS or RTS Rising Edge */
+#define UART_IIR_FIFO_EN            (0xc0)
+#define UART_IIR_INT_MASK           (0x1f)
+
+/* RateFix */
+#define UART_RATE_FIX               (1 << 0)
+//#define UART_AUTORATE_FIX           (1 << 1)
+//#define UART_FREQ_SEL               (1 << 2)
+#define UART_FREQ_SEL               (1 << 1)
+
+#define UART_RATE_FIX_13M           (1 << 0) /* means UARTclk = APBclk / 4 */
+#define UART_AUTORATE_FIX_13M       (1 << 1)
+#define UART_FREQ_SEL_13M           (1 << 2)
+#define UART_RATE_FIX_ALL_13M       (UART_RATE_FIX_13M|UART_AUTORATE_FIX_13M| \
+                                     UART_FREQ_SEL_13M)
+
+#define UART_RATE_FIX_26M           (0 << 0) /* means UARTclk = APBclk / 2 */
+#define UART_AUTORATE_FIX_26M       (0 << 1)
+#define UART_FREQ_SEL_26M           (0 << 2)
+#define UART_RATE_FIX_ALL_26M       (UART_RATE_FIX_26M|UART_AUTORATE_FIX_26M| \
+                                     UART_FREQ_SEL_26M)
+
+#define UART_RATE_FIX_32M5          (0 << 0)    /* means UARTclk = APBclk / 2 */
+#define UART_FREQ_SEL_32M5          (0 << 1)
+#define UART_RATE_FIX_ALL_32M5      (UART_RATE_FIX_32M5|UART_FREQ_SEL_32M5)
+
+#define UART_RATE_FIX_16M25         (0 << 0)    /* means UARTclk = APBclk / 4 */
+#define UART_FREQ_SEL_16M25         (0 << 1)
+#define UART_RATE_FIX_ALL_16M25     (UART_RATE_FIX_16M25|UART_FREQ_SEL_16M25)
+
+extern void mtk_set_current_uart(MTK_UART uart_base);
+extern int mtk_get_current_uart(void);
+
+#endif /* !___MTK_UART_H__ */

--- a/platform/mediatek/mt6735/interrupts.c
+++ b/platform/mediatek/mt6735/interrupts.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2008, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name of Google, Inc. nor the names of its contributors
+ *    may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <arch/arm.h>
+#include <reg.h>
+#include <kernel/thread.h>
+#include <platform/interrupts.h>
+#include <sync_write.h>
+#include <platform/mt_typedefs.h>
+#include <platform/mt_reg_base.h>
+#include <platform/mt_gpt.h>
+#include <platform/mt_irq.h>
+
+#include <debug.h>
+
+#define GIC_ICDISER0    (GIC_DIST_BASE + 0x100)
+#define GIC_ICDISER1    (GIC_DIST_BASE + 0x104)
+#define GIC_ICDISER2    (GIC_DIST_BASE + 0x108)
+#define GIC_ICDISER3    (GIC_DIST_BASE + 0x10C)
+#define GIC_ICDISER4    (GIC_DIST_BASE + 0x110)
+#define GIC_ICDISER5    (GIC_DIST_BASE + 0x114)
+#define GIC_ICDISER6    (GIC_DIST_BASE + 0x118)
+#define GIC_ICDISER7    (GIC_DIST_BASE + 0x11C)
+
+#define GIC_ICDICER0    (GIC_DIST_BASE + 0x180)
+#define GIC_ICDICER1    (GIC_DIST_BASE + 0x184)
+#define GIC_ICDICER2    (GIC_DIST_BASE + 0x188)
+#define GIC_ICDICER3    (GIC_DIST_BASE + 0x18C)
+#define GIC_ICDICER4    (GIC_DIST_BASE + 0x190)
+#define GIC_ICDICER5    (GIC_DIST_BASE + 0x194)
+#define GIC_ICDICER6    (GIC_DIST_BASE + 0x198)
+#define GIC_ICDICER7    (GIC_DIST_BASE + 0x19C)
+
+#define INT_POL_CTL0  (MCUCFG_BASE + 0x620)
+
+static void mt_gic_cpu_init(void)
+{
+    DRV_WriteReg32(GIC_CPU_BASE + GIC_CPU_PRIMASK, 0xF0);
+    DRV_WriteReg32(GIC_CPU_BASE + GIC_CPU_CTRL, 0x1);
+    dsb();
+}
+
+static void mt_gic_dist_init(void)
+{
+    unsigned int i;
+#ifndef MTK_FORCE_CLUSTER1
+    unsigned int cpumask = 1 << 0;
+#else
+    unsigned int cpumask = 1 << 4;
+#endif
+
+    cpumask |= cpumask << 8;
+    cpumask |= cpumask << 16;
+
+    DRV_WriteReg32(GIC_DIST_BASE + GIC_DIST_CTRL, 0);
+
+    /*
+     * Set all global interrupts to be level triggered, active low.
+     */
+    for (i = 32; i < (MT_NR_SPI + 32); i += 16) {
+        DRV_WriteReg32(GIC_DIST_BASE + GIC_DIST_CONFIG + i * 4 / 16, 0);
+    }
+
+    /*
+     * Set all global interrupts to this CPU only.
+     */
+    for (i = 32; i < (MT_NR_SPI + 32); i += 4) {
+        DRV_WriteReg32(GIC_DIST_BASE + GIC_DIST_TARGET + i * 4 / 4, cpumask);
+    }
+
+    /*
+     * Set priority on all interrupts.
+     */
+    for (i = 0; i < NR_IRQ_LINE; i += 4) {
+        DRV_WriteReg32(GIC_DIST_BASE + GIC_DIST_PRI + i * 4 / 4, 0xA0A0A0A0);
+    }
+
+	  /*
+	  * Disable all interrupts.
+	  */
+	  for (i = 0; i < NR_IRQ_LINE; i += 32) {
+        DRV_WriteReg32(GIC_DIST_BASE + GIC_DIST_ENABLE_CLEAR + i * 4 / 32, 0xFFFFFFFF);
+    }
+
+dsb();
+
+    DRV_WriteReg32(GIC_DIST_BASE + GIC_DIST_CTRL, 1);
+}
+
+void platform_init_interrupts(void)
+{
+	mt_gic_dist_init();
+	mt_gic_cpu_init();
+}
+
+void platform_deinit_interrupts(void)
+{
+        unsigned int irq;
+
+        DRV_WriteReg32(GIC_ICDICER0, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER1, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER2, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER3, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER4, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER5, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER6, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER7, 0xFFFFFFFF);
+        dsb();
+
+        while((irq = DRV_Reg32(GIC_CPU_BASE + GIC_CPU_INTACK)) != 1023 ) {
+            DRV_WriteReg32(GIC_CPU_BASE + GIC_CPU_EOI, irq);
+        }
+}
+
+extern void lk_scheduler(void);
+//extern void lk_usb_scheduler(void);
+extern void lk_nand_irq_handler(unsigned int irq);
+//extern void lk_msdc_irq_handler(unsigned int irq);
+#ifdef DUMMY_AP
+extern void dummy_ap_irq_handler(unsigned int irq);
+#endif
+
+enum handler_return platform_irq(struct arm_iframe *frame)
+{
+	unsigned int irq = DRV_Reg32(GIC_CPU_BASE + GIC_CPU_INTACK);
+
+	if(irq == MT_GPT_IRQ_ID)
+		lk_scheduler();
+//	else if(irq == MT_USB0_IRQ_ID)
+//		lk_usb_scheduler();
+#ifndef MTK_EMMC_SUPPORT
+//	else if(irq == MT_NFI_IRQ_ID)
+//		lk_nand_irq_handler(irq);
+#endif
+//	else if(irq == MT_MSDC0_IRQ_ID || irq == MT_MSDC1_IRQ_ID)
+//		lk_msdc_irq_handler(irq);
+
+#ifdef DUMMY_AP
+	dummy_ap_irq_handler(irq);
+#endif
+
+	//return INT_NO_RESCHEDULE;
+	return INT_RESCHEDULE;
+}
+
+void platform_fiq(struct arm_iframe *frame)
+{
+
+}
+
+void mt_irq_set_polarity(unsigned int irq, unsigned int polarity)
+{
+    unsigned int offset;
+    unsigned int reg_index;
+    unsigned int value;
+
+    // peripheral device's IRQ line is using GIC's SPI, and line ID >= GIC_PRIVATE_SIGNALS
+    if (irq < GIC_PRIVATE_SIGNALS) {
+        return;
+    }
+
+    offset = (irq - GIC_PRIVATE_SIGNALS) & 0x1F;
+    reg_index = (irq - GIC_PRIVATE_SIGNALS) >> 5;
+    if (polarity == 0) {
+        value = DRV_Reg32(INT_POL_CTL0 + (reg_index * 4));
+        value |= (1 << offset); // always invert the incoming IRQ's polarity
+        DRV_WriteReg32((INT_POL_CTL0 + (reg_index * 4)), value);
+    }else {
+        value = DRV_Reg32(INT_POL_CTL0 + (reg_index * 4));
+        value &= ~(0x1 << offset);
+        DRV_WriteReg32(INT_POL_CTL0 + (reg_index * 4), value);
+    }
+}
+
+void mt_irq_set_sens(unsigned int irq, unsigned int sens)
+{
+    unsigned int config;
+
+    if (sens == MT65xx_EDGE_SENSITIVE) {
+        config = DRV_Reg32(GIC_DIST_BASE + GIC_DIST_CONFIG + (irq / 16) * 4);
+        config |= (0x2 << (irq % 16) * 2);
+        DRV_WriteReg32(GIC_DIST_BASE + GIC_DIST_CONFIG + (irq / 16) * 4, config);
+    }else {
+        config = DRV_Reg32(GIC_DIST_BASE + GIC_DIST_CONFIG + (irq / 16) * 4);
+        config &= ~(0x2 << (irq % 16) * 2);
+        DRV_WriteReg32( GIC_DIST_BASE + GIC_DIST_CONFIG + (irq / 16) * 4, config);
+    }
+    dsb();
+}
+
+/*
+ * mt_irq_mask: mask one IRQ
+ * @irq: IRQ line of the IRQ to mask
+ */
+void mt_irq_mask(unsigned int irq)
+{
+    unsigned int mask = 1 << (irq % 32);
+
+    DRV_WriteReg32(GIC_DIST_BASE + GIC_DIST_ENABLE_CLEAR + irq / 32 * 4, mask);
+    dsb();
+}
+
+/*
+ * mt_irq_unmask: unmask one IRQ
+ * @irq: IRQ line of the IRQ to unmask
+ */
+void mt_irq_unmask(unsigned int irq)
+{
+    unsigned int mask = 1 << (irq % 32);
+
+    DRV_WriteReg32(GIC_DIST_BASE + GIC_DIST_ENABLE_SET + irq / 32 * 4, mask);
+    dsb();
+}
+
+/*
+ * mt_irq_mask: mask one IRQ
+ * @irq: IRQ line of the IRQ to mask
+ */
+void mt_irq_ack(unsigned int irq)
+{
+    DRV_WriteReg32(GIC_CPU_BASE + GIC_CPU_EOI, irq);
+    dsb();
+}
+
+/*
+ * mt_irq_mask_all: mask all IRQ lines. (This is ONLY used for the sleep driver)
+ * @mask: pointer to struct mtk_irq_mask for storing the original mask value.
+ * Return 0 for success; return negative values for failure.
+ */
+int mt_irq_mask_all(struct mtk_irq_mask *mask)
+{
+    if (mask) {
+
+        mask->mask0 = DRV_Reg32(GIC_ICDISER0);
+        mask->mask1 = DRV_Reg32(GIC_ICDISER1);
+        mask->mask2 = DRV_Reg32(GIC_ICDISER2);
+        mask->mask3 = DRV_Reg32(GIC_ICDISER3);
+        mask->mask4 = DRV_Reg32(GIC_ICDISER4);
+        mask->mask5 = DRV_Reg32(GIC_ICDISER5);
+        mask->mask6 = DRV_Reg32(GIC_ICDISER6);
+        mask->mask7 = DRV_Reg32(GIC_ICDISER7);
+
+        DRV_WriteReg32(GIC_ICDICER0, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER1, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER2, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER3, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER4, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER5, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER6, 0xFFFFFFFF);
+        DRV_WriteReg32(GIC_ICDICER7, 0xFFFFFFFF);
+
+        dsb();
+
+        mask->header = IRQ_MASK_HEADER;
+        mask->footer = IRQ_MASK_FOOTER;
+
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
+/*
+ * mt_irq_mask_restore: restore all IRQ lines' masks. (This is ONLY used for the sleep driver)
+ * @mask: pointer to struct mtk_irq_mask for storing the original mask value.
+ * Return 0 for success; return negative values for failure.
+ */
+int mt_irq_mask_restore(struct mtk_irq_mask *mask)
+{
+    if (!mask) {
+        return -1;
+    }
+    if (mask->header != IRQ_MASK_HEADER) {
+        return -1;
+    }
+    if (mask->footer != IRQ_MASK_FOOTER) {
+        return -1;
+    }
+
+    DRV_WriteReg32(GIC_ICDISER0,mask->mask0);
+    DRV_WriteReg32(GIC_ICDISER1,mask->mask1);
+    DRV_WriteReg32(GIC_ICDISER2,mask->mask2);
+    DRV_WriteReg32(GIC_ICDISER3,mask->mask3);
+    DRV_WriteReg32(GIC_ICDISER4,mask->mask4);
+    DRV_WriteReg32(GIC_ICDISER5,mask->mask5);
+    DRV_WriteReg32(GIC_ICDISER6,mask->mask6);
+    DRV_WriteReg32(GIC_ICDISER7,mask->mask7);
+
+    dsb();
+
+
+    return 0;
+}

--- a/platform/mediatek/mt6735/mt_gpt.c
+++ b/platform/mediatek/mt6735/mt_gpt.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2015 MediaTek Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <sys/types.h>
+#include <debug.h>
+#include <err.h>
+#include <reg.h>
+
+#include <platform/mt_typedefs.h>
+#include <platform/mt_reg_base.h>
+#include <platform/mt_gpt.h>
+
+#define AP_PERI_GLOBALCON_PDN0 (PERICFG_BASE+0x10)
+
+static void gpt_power_on(bool bPowerOn)
+{
+    if (!bPowerOn) {
+        DRV_SetReg32(AP_PERI_GLOBALCON_PDN0, 1<<13);
+    } else {
+        DRV_ClrReg32(AP_PERI_GLOBALCON_PDN0, 1<<13);
+    }
+}
+
+static void gpt4_start(void)
+{
+    DRV_WriteReg32(GPT4_CLK_REG, GPT4_SYS_CLK);
+    DRV_WriteReg32(GPT4_CON_REG, GPT4_EN|GPT4_FREERUN);
+}
+
+static void gpt4_stop(void)
+{
+    DRV_WriteReg32(GPT4_CON_REG, 0x0); // disable
+    DRV_WriteReg32(GPT4_CON_REG, 0x2); // clear counter
+}
+
+static void gpt4_init(bool bStart)
+{
+    gpt4_stop();
+
+    if (bStart) {
+        gpt4_start();
+    }
+}
+
+void gpt_init(void)
+{
+    gpt_power_on(TRUE);
+
+    gpt4_init(TRUE);
+}

--- a/platform/mediatek/mt6735/platform.c
+++ b/platform/mediatek/mt6735/platform.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2015 MediaTek Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <debug.h>
+#include <stdlib.h>
+#include <string.h>
+#include <err.h>
+#include <reg.h>
+#include <sys/types.h>
+#include <kernel/vm.h>
+#include <platform.h>
+#include <dev/uart.h>
+#include <arch/arm.h>
+#include <arch/arm/mmu.h>
+#include <arch/ops.h>
+#include <platform/mt_reg_base.h>
+#include <platform/mt_typedefs.h>
+#include <platform/mt_gpt.h>
+#include <platform/mt_irq.h>
+
+#define MTK_WDT_MODE TOPRGU_BASE
+
+struct mmu_initial_mapping mmu_initial_mappings[] = {
+    // XXX needs to be filled in
+
+    /* Note: mapping entry should be 1MB alignment (address and size will be masked to 1MB boundaries in arch/arm/arm/start.S) */
+
+    /* mcusys (peripherals) */
+    {
+        .phys = (uint64_t)0,
+        .virt = (uint32_t)0,
+        .size = 0x40000000,
+        .flags = MMU_INITIAL_MAPPING_FLAG_DEVICE,
+        .name = "mcusys"
+    },
+    /* ram */
+    {
+        .phys = (uint64_t)0x40000000,
+        .virt = (uint32_t)0x40000000,
+        .size = 0xc0000000,
+        .flags = 0,
+        .name = "ram"
+    },
+
+    /* null entry to terminate the list */
+    { 0 }
+};
+
+static pmm_arena_t arena = {
+    .name = "dram",
+    .base = MEMBASE,
+    .size = MEMSIZE,
+    .flags = PMM_ARENA_FLAG_KMAP,
+};
+
+void platform_init_mmu_mappings(void)
+{
+}
+
+void platform_early_init(void)
+{
+    uart_init_early();
+
+    platform_init_interrupts();
+
+    gpt_init();
+
+    /* disable WDT */
+    DRV_WriteReg32(MTK_WDT_MODE, 0x22000000);
+
+    pmm_add_arena(&arena);
+}
+
+void platform_init(void)
+{
+}

--- a/platform/mediatek/mt6735/rules.mk
+++ b/platform/mediatek/mt6735/rules.mk
@@ -1,0 +1,27 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+MODULE := $(LOCAL_DIR)
+
+ARCH    := arm
+ARM_CPU := cortex-a7
+CPU     := generic
+WITH_SMP ?= 0
+
+GLOBAL_INCLUDES += \
+	$(LOCAL_DIR)/../../include/sys \
+	$(LOCAL_DIR)/$(SUB_PLATFORM)/include
+
+MODULE_SRCS += \
+	$(LOCAL_DIR)/platform.c \
+	$(LOCAL_DIR)/uart.c \
+	$(LOCAL_DIR)/interrupts.c \
+	$(LOCAL_DIR)/timer.c \
+	$(LOCAL_DIR)/debug.c \
+	$(LOCAL_DIR)/mt_gpt.c
+
+KERNEL_BASE = $(MEMBASE)
+
+
+include platform/mediatek/common/rules.mk
+
+include make/module.mk

--- a/platform/mediatek/mt6735/timer.c
+++ b/platform/mediatek/mt6735/timer.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2008 Travis Geiselbrecht
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <sys/types.h>
+#include <debug.h>
+#include <err.h>
+#include <reg.h>
+#include <platform/timer.h>
+#include <platform/mt_typedefs.h>
+#include <platform/mt_reg_base.h>
+#include <platform/mt_gpt.h>
+#include <platform/mt_irq.h>
+
+#include <kernel/thread.h>
+
+static lk_time_t system_time = 0;
+static volatile lk_time_t ticks = 0;
+static lk_time_t tick_interval;
+
+static platform_timer_callback time_callback;
+static void *callback_arg;
+
+#define AP_PERI_GLOBALCON_PDN0 (PERICFG_BASE+0x10)
+
+#define TIMER_TICK_RATE 32768
+
+static enum handler_return timer_irq(void *arg)
+{
+	ticks += tick_interval;
+	return time_callback(callback_arg, ticks);
+}
+
+void lk_scheduler(void)
+{
+	//static enum handler_return ret;
+
+	/* ack GPT5 irq */
+	DRV_WriteReg32(GPT_IRQACK_REG, 0x10);
+	DRV_WriteReg32(GPT5_CON_REG, GPT_CLEAR);
+	DRV_WriteReg32(GPT5_CON_REG, GPT_DISABLE);
+
+	timer_irq(0);
+
+	/*
+	 * CAUTION! The de-assert signal to GIC might delay serveral clocks.
+	 * Here must have enough delay to make sure the GPT signal had arrived GIC.
+	 */
+	/* ack GIC irq */
+	mt_irq_ack(MT_GPT_IRQ_ID);
+
+	/* enable GPT5 */
+	DRV_WriteReg32(GPT5_CON_REG, GPT_ENABLE|GPT_MODE4_ONE_SHOT);
+
+}
+
+status_t platform_set_periodic_timer(platform_timer_callback callback, void *arg, lk_time_t interval)
+{
+	time_callback = callback;
+	tick_interval = interval;
+	callback_arg  = arg;
+
+	DRV_WriteReg32(GPT_IRQEN_REG, 0);
+	DRV_WriteReg32(GPT_IRQACK_REG, 0x3f);
+
+	mt_irq_set_sens(MT_GPT_IRQ_ID, MT65xx_LEVEL_SENSITIVE);
+	mt_irq_set_polarity(MT_GPT_IRQ_ID, MT65xx_POLARITY_LOW);
+
+	DRV_WriteReg32(GPT5_CON_REG, 0x02);
+	DRV_WriteReg32(GPT_IRQACK_REG, 0x10);
+	DRV_WriteReg32(GPT5_CLK_REG , 0x10);
+
+	DRV_WriteReg32(GPT5_COMPARE_REG, TIMER_TICK_RATE*interval/1000);
+	DRV_WriteReg32(GPT_IRQEN_REG, 0x10);
+
+	mt_irq_unmask(MT_GPT_IRQ_ID);
+
+	DRV_WriteReg32(GPT5_CON_REG, GPT_ENABLE|GPT_MODE4_ONE_SHOT);
+
+	return NO_ERROR;
+}
+
+lk_time_t current_time(void)
+{
+	return ticks;
+}
+
+lk_bigtime_t current_time_hires(void)
+{
+    lk_bigtime_t time;
+
+    time = (lk_bigtime_t)ticks * 1000;
+    return time;
+}
+
+static void gpt_power_on (bool bPowerOn)
+{
+    if (!bPowerOn) {
+        DRV_SetReg32(AP_PERI_GLOBALCON_PDN0, 1<<13);
+    } else {
+        DRV_ClrReg32(AP_PERI_GLOBALCON_PDN0, 1<<13);
+    }
+}
+
+void platform_early_init_timer(void)
+{
+	//dprintf(SPEW, "platform_early_init_timer\n");
+
+	gpt_power_on(1);
+}

--- a/platform/mediatek/mt6735/uart.c
+++ b/platform/mediatek/mt6735/uart.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2015 MediaTek Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <debug.h>
+#include <reg.h>
+#include <dev/uart.h>
+#include <string.h>
+
+#include <platform/mt_typedefs.h>
+#include <platform/mt_reg_base.h>
+#include <platform/mt_uart.h>
+#include <sync_write.h>
+
+// output uart port
+static volatile unsigned int g_uart;
+// output uart baudrate
+static unsigned int g_brg;
+
+static void uart_setbrg(void)
+{
+    unsigned int byte,speed;
+    unsigned int highspeed;
+    unsigned int quot, divisor, remainder;
+    unsigned int uartclk;
+    unsigned short data, high_speed_div, sample_count, sample_point;
+    unsigned int tmp_div;
+
+    speed = g_brg;
+    uartclk = UART_SRC_CLK;
+
+    if (speed <= 115200 ) {
+        highspeed = 0;
+        quot = 16;
+    } else {
+        highspeed = 3;
+        quot = 1;
+    }
+
+    if (highspeed < 3) { /*0~2*/
+        /* Set divisor DLL and DLH  */
+        divisor   =  uartclk / (quot * speed);
+        remainder =  uartclk % (quot * speed);
+
+        if (remainder >= (quot / 2) * speed)
+            divisor += 1;
+
+        mt_reg_sync_writew(highspeed, UART_HIGHSPEED(g_uart));
+        byte = DRV_Reg32(UART_LCR(g_uart));   /* DLAB start */
+        mt_reg_sync_writel((byte | UART_LCR_DLAB), UART_LCR(g_uart));
+        mt_reg_sync_writel((divisor & 0x00ff), UART_DLL(g_uart));
+        mt_reg_sync_writel(((divisor >> 8)&0x00ff), UART_DLH(g_uart));
+        mt_reg_sync_writel(byte, UART_LCR(g_uart));   /* DLAB end */
+    } else {
+        data=(unsigned short)(uartclk/speed);
+        high_speed_div = (data>>8) + 1; // divided by 256
+
+        tmp_div=uartclk/(speed*high_speed_div);
+        divisor =  (unsigned short)tmp_div;
+
+        remainder = (uartclk)%(high_speed_div*speed);
+        /*get (sample_count+1)*/
+        if (remainder >= ((speed)*(high_speed_div))>>1)
+            divisor =  (unsigned short)(tmp_div+1);
+        else
+            divisor =  (unsigned short)tmp_div;
+
+        sample_count=divisor-1;
+
+        /*get the sample point*/
+        sample_point=(sample_count-1)>>1;
+
+        /*configure register*/
+        mt_reg_sync_writel(highspeed, UART_HIGHSPEED(g_uart));
+
+        byte = DRV_Reg32(UART_LCR(g_uart));    /* DLAB start */
+        mt_reg_sync_writel((byte | UART_LCR_DLAB), UART_LCR(g_uart));
+        mt_reg_sync_writel((high_speed_div & 0x00ff), UART_DLL(g_uart));
+        mt_reg_sync_writel(((high_speed_div >> 8)&0x00ff), UART_DLH(g_uart));
+        mt_reg_sync_writel(sample_count, UART_SAMPLE_COUNT(g_uart));
+        mt_reg_sync_writel(sample_point, UART_SAMPLE_POINT(g_uart));
+        mt_reg_sync_writel(byte, UART_LCR(g_uart));   /* DLAB end */
+    }
+}
+
+void mtk_set_current_uart(MTK_UART uart_base)
+{
+    g_uart = uart_base;
+}
+
+int mtk_get_current_uart(void)
+{
+    return g_uart;
+}
+
+void uart_init_early(void)
+{
+    mtk_set_current_uart(UART1);
+
+    DRV_SetReg32(UART_FCR(g_uart), UART_FCR_FIFO_INIT); /* clear fifo */
+    mt_reg_sync_writew(UART_NONE_PARITY | UART_WLS_8 | UART_1_STOP, UART_LCR(g_uart));
+    g_brg = CONFIG_BAUDRATE;
+    uart_setbrg();
+}
+
+void uart_init(void)
+{
+}
+
+void uart_flush_tx(int port)
+{
+}
+
+void uart_flush_rx(int port)
+{
+}
+
+void uart_init_port(int port, uint baud)
+{
+}
+
+int uart_putc(int port, char c)
+{
+    while (!(DRV_Reg32(UART_LSR(port)) & UART_LSR_THRE));
+
+    if (c == '\n')
+        mt_reg_sync_writel((unsigned int)'\r', UART_THR(port));
+
+    mt_reg_sync_writel((unsigned int)c, UART_THR(port));
+
+    return 0;
+}
+
+int uart_getc(int port, bool wait)
+{
+    while (!(DRV_Reg32(UART_LSR(port)) & UART_LSR_DR));
+    return (int)DRV_Reg32(UART_RBR(port));
+}

--- a/project/mt6735.mk
+++ b/project/mt6735.mk
@@ -1,0 +1,6 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+TARGET := mt6735
+
+MODULES += \
+	app/shell

--- a/target/mt6735/init.c
+++ b/target/mt6735/init.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 MediaTek Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <debug.h>
+#include <reg.h>
+#include <target.h>
+
+void target_early_init(void)
+{
+}
+
+void target_init(void)
+{
+}

--- a/target/mt6735/rules.mk
+++ b/target/mt6735/rules.mk
@@ -1,0 +1,18 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+MODULE := $(LOCAL_DIR)
+
+PLATFORM := mediatek
+SUB_PLATFORM := mt6735
+
+MEMBASE := 0x41E00000
+
+MEMSIZE := 0x00900000
+
+GLOBAL_DEFINES += \
+	MEMBASE=$(MEMBASE)
+
+MODULE_SRCS += \
+	$(LOCAL_DIR)/init.c
+
+include make/module.mk


### PR DESCRIPTION
These set of patches were originated from platform and project mt6797 which commited by Mediatek.

According to the source release from vendor “Raindi Technology"(http://www.raindi.com.cn/), you can buy development board of mt6735 from Taobao (https://world.taobao.com/item/539050522155.htm) and get the reference SDK.

Hence I'm trying to port development board "Project: ap7350_65u_l1" of platform mt6735 from the following release back to mainline of little kernel.
http://git.huayusoft.com/tomsu/AP7350_MDK-kernel
https://github.com/alexgoussev/AP7350_MDK-kernel

While this board and the platform is a famous low-end product, to get support in the mainline little kernel will be good to all developers.