### PR TITLE
[arch][arm64] Fix barriers in startup code

### DIFF
--- a/arch/arm64/start.S
+++ b/arch/arm64/start.S
@@ -286,8 +286,8 @@ arm_reset:
 
     /* Invalidate TLB */
     tlbi    vmalle1is
-    isb
     dsb     sy
+    isb
 
     /* Initialize Memory Attribute Indirection Register */
     ldr     tmp, =MMU_MAIR_VAL
@@ -331,6 +331,7 @@ arm_reset:
 
     /* Invalidate TLB */
     tlbi    vmalle1
+    dsb     sy
     isb
 
 #if WITH_SMP


### PR DESCRIPTION
After a TLBI instruction the right thing to do is to execute DSB followed by ISB. DSB ensures that the TLBI is seen by all observers of the system and ISB ensures that the DSB has finished before continuing.