### PR TITLE
[arch][arm] Fix execution of TLBIALL instructions

### DIFF
--- a/arch/arm/arm/start.S
+++ b/arch/arm/arm/start.S
@@ -282,9 +282,9 @@ arm_reset:
        r8 == final translation table physical (if using trampoline)
     */
 .Lmmu_setup:
-    /* Invalidate TLB */
-    mov     r12, #0
-    mcr     p15, 0, r12, c8, c7, 0
+    /* Invalidate TLB. The value in r0 is ignored */
+    mcr     p15, 0, r0, c8, c7, 0
+    dsb     sy
     isb
 
     /* Write 0 to TTBCR */
@@ -326,9 +326,9 @@ arm_reset:
     isb
 #endif
 
-    /* Invalidate TLB */
-    mov     r12, #0
-    mcr     p15, 0, r12, c8, c7, 0
+    /* Invalidate TLB. The value in r0 is ignored */
+    mcr     p15, 0, r0, c8, c7, 0
+    dsb     sy
     isb
 
     /* assume lr was in physical memory, adjust it before returning */


### PR DESCRIPTION
After a TLBI instruction the right thing to do is to execute DSB followed by ISB. DSB ensures that the TLBI is seen by all observers of the system and ISB ensures that the DSB has finished before continuing.

Also, the value in `<Rt>` is ignored for a TLBIALL. It isn't needed to load 0 to r12 and then use r12 in the instruction. In order not to cause confusion it is better to not load anything to r12.