### PR TITLE
[lib][bio] sub device inherits parent device erase_byte

### DIFF
--- a/lib/bio/subdev.c
+++ b/lib/bio/subdev.c
@@ -175,6 +175,7 @@ status_t bio_publish_subdevice(const char *parent_dev,
                         geometry_count, geometry, BIO_FLAGS_NONE);
 
     sub->parent = parent;
+    sub->dev.erase_byte = parent->erase_byte;
     sub->offset = startblock;
 
     sub->dev.read = &subdev_read;


### PR DESCRIPTION
Sub device inherits parent device erase_byte.
Nand flash device is with erase_byte = 0xFF, but in bio_publish_subdevice,
the sub device erase_byte will be with initial value 0.
When the image with the chunk of 0, the chunk is not written, but the
read value is 0xFF.

Signed-off-by: Pibben <pibben.tung@mediatek.com>