### PR TITLE
Adds Support for STM32F401CCU6 board

### DIFF
--- a/external/platform/stm32f4xx/STM32F4xx_StdPeriph_Driver/CMSIS/stm32f4xx.h
+++ b/external/platform/stm32f4xx/STM32F4xx_StdPeriph_Driver/CMSIS/stm32f4xx.h
@@ -63,6 +63,10 @@
 #define STM32F40_41xxx
 #endif
 
+#ifdef STM32F401XX
+#define STM32F401xx
+#endif
+
 #define assert_param(x)
  
 /** @addtogroup Library_configuration_section

--- a/external/platform/stm32f4xx/STM32F4xx_StdPeriph_Driver/rules.mk
+++ b/external/platform/stm32f4xx/STM32F4xx_StdPeriph_Driver/rules.mk
@@ -45,7 +45,9 @@ MODULE_SRCS += \
 	$(LOCAL_DIR)/src/stm32f4xx_wwdg.c \
 	$(LOCAL_DIR)/src/system_stm32f4xx.c
 
-ifeq ($(STM32_CHIP),stm32f429)
+ifeq ($(STM32_CHIP),stm32f401)
+
+else ifeq ($(STM32_CHIP),stm32f429)
 	MODULE_SRCS += $(LOCAL_DIR)/src/stm32f4xx_fmc.c
 else
 	MODULE_SRCS += $(LOCAL_DIR)/src/stm32f4xx_fsmc.c

--- a/platform/stm32f4xx/rules.mk
+++ b/platform/stm32f4xx/rules.mk
@@ -25,6 +25,10 @@ ifeq ($(STM32_CHIP),stm32f429)
 FOUND_CHIP := true
 GLOBAL_DEFINES += STM32F429_439xx
 endif
+ifeq ($(STM32_CHIP),stm32f401)
+FOUND_CHIP := true
+GLOBAL_DEFINES += STM32F401xx
+endif
 
 ifeq ($(FOUND_CHIP),)
 $(error unknown STM32F4xx chip $(STM32_CHIP))

--- a/platform/stm32f4xx/vectab.c
+++ b/platform/stm32f4xx/vectab.c
@@ -50,7 +50,6 @@ DEFAULT_HANDLER(EXTI1_IRQ);
 DEFAULT_HANDLER(EXTI2_IRQ);
 DEFAULT_HANDLER(EXTI3_IRQ);
 DEFAULT_HANDLER(EXTI4_IRQ);
-
 DEFAULT_HANDLER(DMA1_Stream0_IRQ);
 DEFAULT_HANDLER(DMA1_Stream1_IRQ);
 DEFAULT_HANDLER(DMA1_Stream2_IRQ);
@@ -58,14 +57,14 @@ DEFAULT_HANDLER(DMA1_Stream3_IRQ);
 DEFAULT_HANDLER(DMA1_Stream4_IRQ);
 DEFAULT_HANDLER(DMA1_Stream5_IRQ);
 DEFAULT_HANDLER(DMA1_Stream6_IRQ);
-
 DEFAULT_HANDLER(ADC_IRQ);
+
+#if defined(STM32F40_41xxx) || defined(STM32F429_439xx)
 DEFAULT_HANDLER(CAN1_TX_IRQ);
 DEFAULT_HANDLER(CAN1_RX0_IRQ);
 DEFAULT_HANDLER(CAN1_RX1_IRQ);
 DEFAULT_HANDLER(CAN1_SCE_IRQ);
 DEFAULT_HANDLER(EXTI9_5_IRQ);
-
 DEFAULT_HANDLER(TIM1_BRK_TIM9_IRQ);
 DEFAULT_HANDLER(TIM1_UP_TIM10_IRQ);
 DEFAULT_HANDLER(TIM1_TRG_COM_TIM11_IRQ);
@@ -73,19 +72,15 @@ DEFAULT_HANDLER(TIM1_CC_IRQ);
 DEFAULT_HANDLER(TIM2_IRQ);
 DEFAULT_HANDLER(TIM3_IRQ);
 DEFAULT_HANDLER(TIM4_IRQ);
-
 DEFAULT_HANDLER(I2C1_EV_IRQ);
 DEFAULT_HANDLER(I2C1_ER_IRQ);
 DEFAULT_HANDLER(I2C2_EV_IRQ);
 DEFAULT_HANDLER(I2C2_ER_IRQ);
-
 DEFAULT_HANDLER(SPI1_IRQ);
 DEFAULT_HANDLER(SPI2_IRQ);
-
 DEFAULT_HANDLER(USART1_IRQ);
 DEFAULT_HANDLER(USART2_IRQ);
 DEFAULT_HANDLER(USART3_IRQ);
-
 DEFAULT_HANDLER(EXTI15_10_IRQ);
 DEFAULT_HANDLER(RTC_Alarm_IRQ);
 DEFAULT_HANDLER(OTG_FS_WKUP_IRQ);
@@ -94,13 +89,11 @@ DEFAULT_HANDLER(TIM8_UP_TIM13_IRQ);
 DEFAULT_HANDLER(TIM8_TRG_COM_TIM14_IRQ);
 DEFAULT_HANDLER(TIM8_CC_IRQ);
 DEFAULT_HANDLER(DMA1_Stream7_IRQ);
-
 #ifdef STM32F40_41xxx
 DEFAULT_HANDLER(FSMC_IRQ);
 #else
-DEFAULT_HANDLER(FMC_IRQ);
+DEFAULT_HANDLER(FMC_IRQ); 
 #endif
-
 DEFAULT_HANDLER(SDIO_IRQ);
 DEFAULT_HANDLER(TIM5_IRQ);
 DEFAULT_HANDLER(SPI3_IRQ);
@@ -108,13 +101,11 @@ DEFAULT_HANDLER(UART4_IRQ);
 DEFAULT_HANDLER(UART5_IRQ);
 DEFAULT_HANDLER(TIM6_DAC_IRQ);
 DEFAULT_HANDLER(TIM7_IRQ);
-
 DEFAULT_HANDLER(DMA2_Stream0_IRQ);
 DEFAULT_HANDLER(DMA2_Stream1_IRQ);
 DEFAULT_HANDLER(DMA2_Stream2_IRQ);
 DEFAULT_HANDLER(DMA2_Stream3_IRQ);
 DEFAULT_HANDLER(DMA2_Stream4_IRQ);
-
 DEFAULT_HANDLER(ETH_IRQ);
 DEFAULT_HANDLER(ETH_WKUP_IRQ);
 DEFAULT_HANDLER(CAN2_TX_IRQ);
@@ -135,6 +126,50 @@ DEFAULT_HANDLER(OTG_HS_IRQ);
 DEFAULT_HANDLER(DCMI_IRQ);
 DEFAULT_HANDLER(CRYP_IRQ);
 DEFAULT_HANDLER(HASH_RNG_IRQ);
+#endif /* STM32F40_41xxx */
+
+#if defined(STM32F401xx) || defined(STM32F411xE)
+DEFAULT_HANDLER(EXTI9_5_IRQ);
+DEFAULT_HANDLER(TIM1_BRK_TIM9_IRQ);
+DEFAULT_HANDLER(TIM1_UP_TIM10_IRQ);
+DEFAULT_HANDLER(TIM1_TRG_COM_TIM11_IRQ);
+DEFAULT_HANDLER(TIM1_CC_IRQ);
+DEFAULT_HANDLER(TIM2_IRQ);
+DEFAULT_HANDLER(TIM3_IRQ);
+DEFAULT_HANDLER(TIM4_IRQ);
+DEFAULT_HANDLER(I2C1_EV_IRQ);
+DEFAULT_HANDLER(I2C1_ER_IRQ);
+DEFAULT_HANDLER(I2C2_EV_IRQ);
+DEFAULT_HANDLER(I2C2_ER_IRQ);
+DEFAULT_HANDLER(SPI1_IRQ);
+DEFAULT_HANDLER(SPI2_IRQ);
+DEFAULT_HANDLER(USART1_IRQ);
+DEFAULT_HANDLER(USART2_IRQ);
+DEFAULT_HANDLER(EXTI15_10_IRQ);
+DEFAULT_HANDLER(RTC_Alarm_IRQ);
+DEFAULT_HANDLER(OTG_FS_WKUP_IRQ);
+DEFAULT_HANDLER(DMA1_Stream7_IRQ);
+DEFAULT_HANDLER(SDIO_IRQ);
+DEFAULT_HANDLER(TIM5_IRQ);
+DEFAULT_HANDLER(SPI3_IRQ);
+DEFAULT_HANDLER(DMA2_Stream0_IRQ);
+DEFAULT_HANDLER(DMA2_Stream1_IRQ);
+DEFAULT_HANDLER(DMA2_Stream2_IRQ);
+DEFAULT_HANDLER(DMA2_Stream3_IRQ);
+DEFAULT_HANDLER(DMA2_Stream4_IRQ);
+DEFAULT_HANDLER(OTG_FS_IRQ);
+DEFAULT_HANDLER(DMA2_Stream5_IRQ);
+DEFAULT_HANDLER(DMA2_Stream6_IRQ);
+DEFAULT_HANDLER(DMA2_Stream7_IRQ);
+DEFAULT_HANDLER(USART6_IRQ);
+DEFAULT_HANDLER(I2C3_EV_IRQ);
+DEFAULT_HANDLER(I2C3_ER_IRQ);
+DEFAULT_HANDLER(FPU_IRQ);
+DEFAULT_HANDLER(SPI4_IRQ);
+#if defined(STM32F411xE)                                               
+DEFAULT_HANDLER(SPI5_IRQ);
+#endif 
+#endif /* STM32F401xx || STM32F411xE */
 
 #define VECTAB_ENTRY(x) [x##n] = stm32_##x
 
@@ -159,6 +194,8 @@ const void *const __SECTION(".text.boot.vectab2") vectab2[] = {
     VECTAB_ENTRY(DMA1_Stream5_IRQ),         /* DMA1 Stream 5 global Interrupt                                    */
     VECTAB_ENTRY(DMA1_Stream6_IRQ),         /* DMA1 Stream 6 global Interrupt                                    */
     VECTAB_ENTRY(ADC_IRQ),                  /* ADC1, ADC2 and ADC3 global Interrupts                             */
+
+#if defined(STM32F40_41xxx) || defined(STM32F429_439xx)
     VECTAB_ENTRY(CAN1_TX_IRQ),              /* CAN1 TX Interrupt                                                 */
     VECTAB_ENTRY(CAN1_RX0_IRQ),             /* CAN1 RX0 Interrupt                                                */
     VECTAB_ENTRY(CAN1_RX1_IRQ),             /* CAN1 RX1 Interrupt                                                */
@@ -225,5 +262,49 @@ const void *const __SECTION(".text.boot.vectab2") vectab2[] = {
     VECTAB_ENTRY(DCMI_IRQ),                 /* DCMI global interrupt                                             */
     VECTAB_ENTRY(CRYP_IRQ),                 /* CRYP crypto global interrupt                                      */
     VECTAB_ENTRY(HASH_RNG_IRQ),             /* Hash and Rng global interrupt                                     */
+#endif /* STM32F40_41xxx) || STM32F429_439xx */
+
+#if defined(STM32F401xx) || defined(STM32F411xE)
+    VECTAB_ENTRY(EXTI9_5_IRQ),              /* External Line[9:5] Interrupts                                     */
+    VECTAB_ENTRY(TIM1_BRK_TIM9_IRQ),        /* TIM1 Break interrupt and TIM9 global interrupt                    */
+    VECTAB_ENTRY(TIM1_UP_TIM10_IRQ),        /* TIM1 Update Interrupt and TIM10 global interrupt                  */
+    VECTAB_ENTRY(TIM1_TRG_COM_TIM11_IRQ),   /* TIM1 Trigger and Commutation Interrupt and TIM11 global interrupt */
+    VECTAB_ENTRY(TIM1_CC_IRQ),              /* TIM1 Capture Compare Interrupt                                    */
+    VECTAB_ENTRY(TIM2_IRQ),                 /* TIM2 global Interrupt                                             */
+    VECTAB_ENTRY(TIM3_IRQ),                 /* TIM3 global Interrupt                                             */
+    VECTAB_ENTRY(TIM4_IRQ),                 /* TIM4 global Interrupt                                             */
+    VECTAB_ENTRY(I2C1_EV_IRQ),              /* I2C1 Event Interrupt                                              */
+    VECTAB_ENTRY(I2C1_ER_IRQ),              /* I2C1 Error Interrupt                                              */
+    VECTAB_ENTRY(I2C2_EV_IRQ),              /* I2C2 Event Interrupt                                              */
+    VECTAB_ENTRY(I2C2_ER_IRQ),              /* I2C2 Error Interrupt                                              */
+    VECTAB_ENTRY(SPI1_IRQ),                 /* SPI1 global Interrupt                                             */
+    VECTAB_ENTRY(SPI2_IRQ),                 /* SPI2 global Interrupt                                             */
+    VECTAB_ENTRY(USART1_IRQ),               /* USART1 global Interrupt                                           */
+    VECTAB_ENTRY(USART2_IRQ),               /* USART2 global Interrupt                                           */
+    VECTAB_ENTRY(EXTI15_10_IRQ),            /* External Line[15:10] Interrupts                                   */
+    VECTAB_ENTRY(RTC_Alarm_IRQ),            /* RTC Alarm (A and B) through EXTI Line Interrupt                   */
+    VECTAB_ENTRY(OTG_FS_WKUP_IRQ),          /* USB OTG FS Wakeup through EXTI line interrupt                     */
+    VECTAB_ENTRY(DMA1_Stream7_IRQ),         /* DMA1 Stream7 Interrupt                                            */
+    VECTAB_ENTRY(SDIO_IRQ),                 /* SDIO global Interrupt                                             */
+    VECTAB_ENTRY(TIM5_IRQ),                 /* TIM5 global Interrupt                                             */
+    VECTAB_ENTRY(SPI3_IRQ),                 /* SPI3 global Interrupt                                             */
+    VECTAB_ENTRY(DMA2_Stream0_IRQ),         /* DMA2 Stream 0 global Interrupt                                    */
+    VECTAB_ENTRY(DMA2_Stream1_IRQ),         /* DMA2 Stream 1 global Interrupt                                    */
+    VECTAB_ENTRY(DMA2_Stream2_IRQ),         /* DMA2 Stream 2 global Interrupt                                    */
+    VECTAB_ENTRY(DMA2_Stream3_IRQ),         /* DMA2 Stream 3 global Interrupt                                    */
+    VECTAB_ENTRY(DMA2_Stream4_IRQ),         /* DMA2 Stream 4 global Interrupt                                    */
+    VECTAB_ENTRY(OTG_FS_IRQ),               /* USB OTG FS global Interrupt                                       */
+    VECTAB_ENTRY(DMA2_Stream5_IRQ),         /* DMA2 Stream 5 global interrupt                                    */
+    VECTAB_ENTRY(DMA2_Stream6_IRQ),         /* DMA2 Stream 6 global interrupt                                    */
+    VECTAB_ENTRY(DMA2_Stream7_IRQ),         /* DMA2 Stream 7 global interrupt                                    */
+    VECTAB_ENTRY(USART6_IRQ),               /* USART6 global interrupt                                           */
+    VECTAB_ENTRY(I2C3_EV_IRQ),              /* I2C3 event interrupt                                              */
+    VECTAB_ENTRY(I2C3_ER_IRQ),              /* I2C3 error interrupt                                              */
+	VECTAB_ENTRY(FPU_IRQ),                  /* FPU global interrupt                                              */
+	VECTAB_ENTRY(SPI4_IRQ),                 /* SPI4 global interrupt                                              */
+#if defined(STM32F411xE)                                               
+	VECTAB_ENTRY(SPI5_IRQ),                 /* SPI5 global interrupt                                              */
+#endif 
+#endif /* STM32F401xx || STM32F411xE */
 };
 

--- a/project/stm32f401-test.mk
+++ b/project/stm32f401-test.mk
@@ -1,0 +1,14 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+TARGET := stm32f401
+
+MODULES += \
+  app/shell \
+  app/stringtests \
+  app/tests \
+  lib/cksum \
+  lib/debugcommands \
+
+WITH_CPP_SUPPORT=true
+
+# Console serial port is on pins PA2(TX) and PA3(RX)

--- a/target/stm32f401/README
+++ b/target/stm32f401/README
@@ -1,0 +1,18 @@
+
+Notes on the STM32F401CCU6 Board
+------------------------------------
+
+https://www.aliexpress.com/item/33011237530.html?spm=a2g0s.9042311.0.0.61624c4dPco7ux
+https://www.electrodragon.com/w/images/d/d4/STM32_Mini_F401_STM32F401CCU6_SCH.jpg
+
+LK Debug/Console UART
+---------------------
+- USART2 is used
+- TX is A2
+- RX is A3
+
+Using external SWD debug
+------------------------
+- SWCLK, SWDIO and GND pins are available on the SWD debug port (opposite the USB-C port)
+
+

--- a/target/stm32f401/include/target/debugconfig.h
+++ b/target/stm32f401/include/target/debugconfig.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012 Travis Geiselbrecht
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef __TARGET_DEBUGCONFIG_H
+#define __TARGET_DEBUGCONFIG_H
+
+#define DEBUG_UART 2
+
+#endif

--- a/target/stm32f401/include/target/gpioconfig.h
+++ b/target/stm32f401/include/target/gpioconfig.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2012 Travis Geiselbrecht
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#ifndef __TARGET_GPIOCONFIG_H
+#define __TARGET_GPIOCONFIG_H
+
+#include <platform/gpio.h>
+
+#define GPIO_USART2_TX GPIO(GPIO_PORT_A, 2)
+#define GPIO_USART2_RX GPIO(GPIO_PORT_A, 3)
+
+#define GPIO_LED0 GPIO(GPIO_PORT_C, 13) // LED - Blue
+
+#endif

--- a/target/stm32f401/init.c
+++ b/target/stm32f401/init.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012 Travis Geiselbrecht
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <lk/err.h>
+#include <lk/debug.h>
+#include <lk/trace.h>
+#include <target.h>
+#include <lk/compiler.h>
+#include <dev/gpio.h>
+#include <stm32f4xx_usart.h>
+#include <stm32f4xx_rcc.h>
+#include <stm32f4xx_gpio.h>
+#include <platform/stm32.h>
+#include <platform/gpio.h>
+#include <target/debugconfig.h>
+#include <target/gpioconfig.h>
+
+void target_early_init(void) {
+#ifdef DEBUG_UART
+#if DEBUG_UART == 2
+    gpio_config(GPIO_USART2_TX, GPIO_STM32_AF |
+                GPIO_STM32_AFn(GPIO_AF_USART2) | GPIO_PULLUP);
+    gpio_config(GPIO_USART2_RX, GPIO_STM32_AF |
+                GPIO_STM32_AFn(GPIO_AF_USART2) | GPIO_PULLUP);
+#endif // DEBUG_UART == 2
+#else
+#warn DEBUG_UART only supports USART2!!!
+#endif // defined DEBUG_UART
+
+    stm32_debug_early_init();
+
+    /* configure some status leds */
+    gpio_config(GPIO_LED0, GPIO_OUTPUT);
+}
+
+void target_init(void) {
+    TRACE_ENTRY;
+
+    stm32_debug_init();
+
+    TRACE_EXIT;
+}
+
+void target_set_debug_led(unsigned int led, bool on) {
+    switch (led) {
+        case 0:
+            gpio_set(GPIO_LED0, on);
+            break;
+    }
+}

--- a/target/stm32f401/rules.mk
+++ b/target/stm32f401/rules.mk
@@ -1,0 +1,26 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+MODULE := $(LOCAL_DIR)
+
+STM32_CHIP := stm32f401
+
+# ROMBASE, MEMBASE, and MEMSIZE are required for the linker script
+ROMBASE ?= 0x08000000
+MEMBASE ?= 0x20000000
+MEMSIZE ?= 65536
+
+PLATFORM := stm32f4xx
+
+GLOBAL_DEFINES += \
+	ENABLE_UART2=1 \
+	TARGET_HAS_DEBUG_LED=1 \
+	HSE_VALUE=25000000 \
+	PLL_M_VALUE=8 \
+	PLL_N_VALUE=336 \
+	PLL_P_VALUE=4
+
+MODULE_SRCS += \
+	$(LOCAL_DIR)/init.c
+
+include make/module.mk
+


### PR DESCRIPTION
. New project (stm32f401-test) and target (stm32f401)
. Modifies the stm32f4xx platform for differences in STM32F401
. Aligns the VecTable (platform/stm32f4xx/vectab.c) with stm32f4xx.h; STM32F401 supports a limited subset of IRQs

Changes to be committed:
	modified:   external/platform/stm32f4xx/STM32F4xx_StdPeriph_Driver/CMSIS/stm32f4xx.h
	modified:   external/platform/stm32f4xx/STM32F4xx_StdPeriph_Driver/rules.mk
	modified:   platform/stm32f4xx/rules.mk
	modified:   platform/stm32f4xx/vectab.c
	new file:   project/stm32f401-test.mk
	new file:   target/stm32f401/README
	new file:   target/stm32f401/include/target/debugconfig.h
	new file:   target/stm32f401/include/target/gpioconfig.h
	new file:   target/stm32f401/init.c
	new file:   target/stm32f401/rules.mk