### PR TITLE
[stm32f0cube][bugfix] Fix race which leads to 0-length SETUP transfers

### DIFF
--- a/external/platform/stm32f0xx/STM32F0xx_HAL_Driver/stm32f0xx_hal_pcd.c
+++ b/external/platform/stm32f0xx/STM32F0xx_HAL_Driver/stm32f0xx_hal_pcd.c
@@ -1250,7 +1250,6 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
         
         else if ((wEPVal & USB_EP_CTR_RX) != 0U)
         {
-          PCD_CLEAR_RX_EP_CTR(hpcd->Instance, PCD_ENDP0);
           /* Get Control Data OUT Packet*/
           ep->xfer_count = PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
           
@@ -1264,6 +1263,7 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
            HAL_PCD_DataOutStageCallback(hpcd, 0U);
           
           PCD_SET_EP_RX_CNT(hpcd->Instance, PCD_ENDP0, ep->maxpacket)
+          PCD_CLEAR_RX_EP_CTR(hpcd->Instance, PCD_ENDP0);
           PCD_SET_EP_RX_STATUS(hpcd->Instance, PCD_ENDP0, USB_EP_RX_VALID)
         }
       }


### PR DESCRIPTION
Fixes a race in the STM USB driver which can lead to the device seeing only 0-length SETUP transfers. The bug ultimately leads to a failed USB enumeration. The race condition is described in further detail below.

The current behavior of the IRQ handler for received OUT transfers is as such:

- Clear RX_CTR bit (at this point, HW sees that SW has acknowledged previous SETUP/OUT transfer, and the HW will now accept new STATUS transfers)
- Call out to the client OutStageCallback (nothing significant here)
- Set EP_RX_CNT back to size of max_packet (was previously set to 0 as we expect to receive 0-length OUT transfer from host. HW uses this value to limit the amount of data it can receive)
- Set RX_STAT back to VALID (the HW can now receive new STATUS/OUT transfers)

The important thing to note here is that even before RX_STAT is set to VALID in the last step, the HW can still receive and process a new SETUP transfer as long as RX_CTR is cleared (the spec has some detail about this under section "Control Transfers" on page 867: https://www.st.com/resource/en/reference_manual/dm00031936.pdf). The race will occur if we receive a SETUP transfer after clearing RX_CTR but before adjusting EP_RX_CNT back to max_packet. In this case, the IRQ handler will run for the newly received SETUP transfer, but the transfer will have no data associated with it (the driver ends up using the previous transfer data which was cached).

We can eliminate the race window by waiting to clear RX_CTR only after we've reset EP_RX_CNT. In this case the HW will ignore any new SETUP transfers until after the EP_RX_CNT is reset back to the desired value.