### PR TITLE
Fix incompatibility with Make 4.3.

### DIFF
--- a/make/macros.mk
+++ b/make/macros.mk
@@ -11,8 +11,8 @@ TOBUILDDIR = $(addprefix $(BUILDDIR)/,$(1))
 TOBOOL = $(if $(filter-out 0 false,$1),true,false)
 
 COMMA := ,
-SPACE :=
-SPACE +=
+E :=
+SPACE := $E $E
 
 # lower case and upper case translation
 LC = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))


### PR DESCRIPTION
The behavior of += has changed such that it will not prepend a space, if the original variable was empty. This breaks the generation of config.h. The fix I've found is to create the variable with two empty variables and a space between, and this seems to work for both Make 4.2 and 4.3.

Source: https://lwn.net/Articles/810071/
```
* WARNING: Backward-incompatibility!
  Previously appending using '+=' to an empty variable would result in a value
  starting with a space.  Now the initial space is only added if the variable
  already contains some value.  Similarly, appending an empty string does not
  add a trailing space.
```