### PR TITLE
[stm32f0xx] Fix prescaler value.

### DIFF
--- a/platform/stm32f0xx/include/platform/timer_capture.h
+++ b/platform/stm32f0xx/include/platform/timer_capture.h
@@ -33,6 +33,9 @@ typedef struct {
 } stm32_timer_capture_t;
 
 // Set tc->chan[] cb and flags before calling.
+//
+// `prescaler` is the desired prescaling factor and must be positive. The value stored in the 
+// prescaler register will be `prescaler - 1` (see ST reference manual RM0091, section 18.4.11).
 status_t stm32_timer_capture_setup(stm32_timer_capture_t *tc, int timer, uint16_t prescaler);
 
 uint64_t stm32_timer_capture_get_counter(stm32_timer_capture_t *tc);

--- a/platform/stm32f0xx/timer_capture.c
+++ b/platform/stm32f0xx/timer_capture.c
@@ -316,6 +316,8 @@ void stm32_TIM17_IRQ(void) {
 }
 
 status_t stm32_timer_capture_setup(stm32_timer_capture_t *tc, int timer, uint16_t prescaler) {
+    assert(prescaler > 0);
+
     tc->config = stm32_timer_get_config(timer);
     if (tc->config == NULL) {
         return ERR_NOT_FOUND;
@@ -329,7 +331,9 @@ status_t stm32_timer_capture_setup(stm32_timer_capture_t *tc, int timer, uint16_
     spin_lock_init(&tc->overflow_lock);
 
     tc->config->regs->CR1 = 0;
-    tc->config->regs->PSC = prescaler;
+
+    // The prescaler value applied by hardware is PSC + 1.
+    tc->config->regs->PSC = prescaler > 0 ? prescaler - 1 : 0;
 
     uint32_t dier =  TIM_DIER_UIE;
 


### PR DESCRIPTION
As specified in ST reference manual RM0091, the prescaling factor
applied by timers is 1 plus the value in the corresponding prescaler
register. (See section 17.4.11 for TIM1, and analogous sections for
other timers.)

This change causes stm32_timer_capture_setup to take the prescaling
factor as input rather than the register value.