### PR TITLE
[platform][tms570-launchpad] Do not try to save d16-d31 on ARMv7-R

### DIFF
--- a/arch/arm/arm/fpu.c
+++ b/arch/arm/arm/fpu.c
@@ -82,9 +82,11 @@ void arm_fpu_thread_swap(struct thread *oldthread, struct thread *newthread) {
 
             __asm__ volatile("vmrs  %0, fpscr" : "=r" (oldthread->arch.fpscr));
             __asm__ volatile("vstm   %0, { d0-d15 }" :: "r" (&oldthread->arch.fpregs[0]));
+#if(!__ARM_ARCH_7R__)
             if (!is_16regs()) {
                 __asm__ volatile("vstm   %0, { d16-d31 }" :: "r" (&oldthread->arch.fpregs[16]));
             }
+#endif
 
             arm_fpu_set_enable(false);
         }
@@ -97,9 +99,11 @@ void arm_fpu_thread_swap(struct thread *oldthread, struct thread *newthread) {
             __asm__ volatile("vmsr  fpscr, %0" :: "r" (newthread->arch.fpscr));
 
             __asm__ volatile("vldm   %0, { d0-d15 }" :: "r" (&newthread->arch.fpregs[0]));
+#if(!__ARM_ARCH_7R__)
             if (!is_16regs()) {
                 __asm__ volatile("vldm   %0, { d16-d31 }" :: "r" (&newthread->arch.fpregs[16]));
             }
+#endif
             write_fpexc(newthread->arch.fpexc);
         } else {
             arm_fpu_set_enable(false);


### PR DESCRIPTION
All shipping ARMv7-R processors include VFPv3-D16, a subset of VFPv3
with only 16 double-precision registers. The first -R profile CPU
with a complete VFP or NEON implementation is the Cortex-R52,
implementing ARMv8-R.

LK's context switch code had a dynamic check and would only save
d16-d31 if present, but gcc/gas will not assemble code that includes
references to d16-d31 when mcpu=cortex-r4f or other v7-R CPUs.

Ideally we'd key the #if off of __TARGET_FPU_VFPV3_D16, but that
only appears to be defined by the ARM compilers, not gcc. Use
V7-R as the key instead.