### PR TITLE
[arch][x86] Unset x86 inner page table entry G bit

### DIFF
--- a/arch/x86/include/arch/x86/mmu.h
+++ b/arch/x86/include/arch/x86/mmu.h
@@ -26,7 +26,7 @@
 
 #ifndef X86_LEGACY
 /* default flags for inner page directory entries */
-#define X86_KERNEL_PD_FLAGS (X86_MMU_PG_G | X86_MMU_PG_RW | X86_MMU_PG_P)
+#define X86_KERNEL_PD_FLAGS (X86_MMU_PG_RW | X86_MMU_PG_P)
 
 /* default flags for 2MB/4MB/1GB page directory entries */
 #define X86_KERNEL_PD_LP_FLAGS (X86_MMU_PG_G | X86_MMU_PG_PS | X86_MMU_PG_RW | X86_MMU_PG_P)


### PR DESCRIPTION
The issue was initially found on AMD machine when run lk with qemu kvm, it
can't boot if kvm hardware is enable in qemu.

According to Intel system programming guild Chapter 4 "Paging",
if the page table entry is non-leaf entry, then the G bit will be
ignored.

However, According to AMD programmer mannul Volume 2, Chapter 5.3
"Long-Mode Page Translation", the non-leaf page table entry G bit
must be zero.

The patch clears inner page table entry G bit to zero so that it
works on both Intel and AMD CPU