### PR TITLE
[arch][arm64] unmask_interrupt needs the same numbers as register_int_handler

### DIFF
--- a/arch/arm64/mp.c
+++ b/arch/arm64/mp.c
@@ -65,7 +65,7 @@ void arch_mp_init_percpu(void) {
     register_int_handler(MP_IPI_GENERIC + GIC_IPI_BASE, &arm_ipi_generic_handler, 0);
     register_int_handler(MP_IPI_RESCHEDULE + GIC_IPI_BASE, &arm_ipi_reschedule_handler, 0);
 
-    //unmask_interrupt(MP_IPI_GENERIC);
-    //unmask_interrupt(MP_IPI_RESCHEDULE);
+    //unmask_interrupt(MP_IPI_GENERIC + GIC_IPI_BASE);
+    //unmask_interrupt(MP_IPI_RESCHEDULE + GIC_IPI_BASE);
 }
 


### PR DESCRIPTION
[arch][arm64] unmask_interrupt needs the same numbers as register_int_handler