### PR TITLE
[arch][arm64] cache maintainance on page tables during boot

### DIFF
--- a/arch/arm64/include/arch/asm_macros.h
+++ b/arch/arm64/include/arch/asm_macros.h
@@ -58,11 +58,21 @@ ldp \ra, \rb, [sp], #16
     add     \new_ptr_end, \new_ptr, #(1 << \size_shift)
     str     \new_ptr_end, [\tmp, #:lo12:boot_alloc_end]
 
+    /* clean and invalidate boot_alloc_end pointer */
+    add     x0, \tmp, #:lo12:boot_alloc_end
+    mov     x1, #8
+    bl      arch_clean_invalidate_cache_range
+
 .if \phys_offset != 0
     /* clear page */
     sub     \new_ptr, \new_ptr, \phys_offset
     sub     \new_ptr_end, \new_ptr_end, \phys_offset
 .endif
+
+    /* clean and invalidate new page */
+    mov     x0, \new_ptr
+    mov     x1, #(1 << \size_shift)
+    bl      arch_clean_invalidate_cache_range
 
     /* clear page */
     mov     \tmp, \new_ptr

--- a/arch/arm64/start.S
+++ b/arch/arm64/start.S
@@ -73,6 +73,17 @@ arm_reset:
     stp     x2, x3, [tmp]
 
 #if WITH_KERNEL_VM
+    /* Ensure that the page tables we will populate do not have stale cache
+     * entries present that would cause a fault when enabling the MMU.
+     */
+    mov x0, page_table0
+    mov x1, (MMU_PAGE_TABLE_ENTRIES_IDENT << 3)
+    bl arch_clean_invalidate_cache_range
+
+    mov x0, page_table1
+    mov x1, (MMU_KERNEL_PAGE_TABLE_ENTRIES_TOP << 3)
+    bl arch_clean_invalidate_cache_range
+
     /* walk through all the entries in the translation table, setting them up */
     mov     tmp, #0
 .Lclear_top_page_table_loop:


### PR DESCRIPTION
Add cache clean + invalidate on the page tables that get modified during
startup before the MMU is enabled. Without this, if these memory regions
were present in cache before LK started, the CPU will see the stale
cached values as soon as the MMU is enabled. Invalidating these forces
the CPU to fetch the correct values from memory after the MMU is enabled.