### PR TITLE
[arch][arm64] disable EL1 FPU traps even when starting at EL1

### DIFF
--- a/arch/arm64/asm.S
+++ b/arch/arm64/asm.S
@@ -117,10 +117,6 @@ FUNCTION(arm64_elX_to_el1)
     mov x4, #(1<<31)
     msr hcr_el2, x4
 
-    /* disable EL1 FPU traps */
-    mov x4, #(0b11<<20)
-    msr cpacr_el1, x4
-
     /* set up the EL1 bounce interrupt */
     mov x4, sp
     msr sp_el1, x4

--- a/arch/arm64/start.S
+++ b/arch/arm64/start.S
@@ -35,6 +35,10 @@ arm_reset:
     /* if we came in at higher than EL1, drop down to EL1 */
     bl      arm64_elX_to_el1
 
+    /* disable EL1 FPU traps */
+    mov     tmp, #(0b11<<20)
+    msr     cpacr_el1, tmp
+
 #if WITH_KERNEL_VM
     /* enable caches so atomics and spinlocks work */
     mrs     tmp, sctlr_el1


### PR DESCRIPTION
It is possible for early initialization functions such as lk_main()
to contain NEON instructions because we don't build the kernel with
-mgeneral-regs-only. As a result we can end up taking an FPU exception
before we are ready to handle it.

We didn't have this problem when starting at a higher exception level
than EL1 because we turned off FPU traps in arm64_elX_to_el1(). But we
neglected to do so when starting at EL1. Fix the problem by moving the
CPACR_EL1 manipulation out of arm64_elX_to_el1() and into arm_reset().