### PR TITLE
[top] use incomplete array declarations for constructor symbols

### DIFF
--- a/top/main.c
+++ b/top/main.c
@@ -29,8 +29,8 @@
 /* saved boot arguments from whoever loaded the system */
 ulong lk_boot_args[4];
 
-extern void *__ctor_list;
-extern void *__ctor_end;
+extern void (*__ctor_list[])(void);
+extern void (*__ctor_end[])(void);
 extern int __bss_start;
 extern int _end;
 
@@ -42,13 +42,13 @@ static uint secondary_bootstrap_thread_count;
 static int bootstrap2(void *arg);
 
 static void call_constructors(void) {
-    void **ctor;
+    void (**ctor)(void);
 
-    ctor = &__ctor_list;
-    while (ctor != &__ctor_end) {
+    ctor = __ctor_list;
+    while (ctor != __ctor_end) {
         void (*func)(void);
 
-        func = (void ( *)(void))*ctor;
+        func = *ctor;
 
         func();
         ctor++;


### PR DESCRIPTION
Clang will omit the initial comparison in this while loop on the
assumption that two different variables will not have the same address,
which will lead to a crash if the kernel has no constructors.

It will, however, retain the comparison for incomplete arrays
because they may have zero size (and therefore may alias with another
variable). Therefore, change the declarations of the start/end symbols
for the constructor list to incomplete arrays.