### PR TITLE
Redundant printf under tcp.c

### DIFF
--- a/lib/minip/tcp.c
+++ b/lib/minip/tcp.c
@@ -994,7 +994,6 @@ status_t tcp_connect(tcp_socket_t **handle, uint32_t addr, uint16_t port) {
 
     // XXX add some entropy to try to better randomize things
     lk_bigtime_t t = current_time_hires();
-    printf("%lld\n", t);
     rand_add_entropy(&t, sizeof(t));
 
     // set up the socket for outgoing connections


### PR DESCRIPTION
When tcp_connect function is fired then it prints some time related redundant output then it ruins the console stdout. We can remove extra printf from tcp