### PR TITLE
[dev][bus][pci] fixed type1_read_byte API bug

### DIFF
--- a/dev/bus/pci/backend/type1.cpp
+++ b/dev/bus/pci/backend/type1.cpp
@@ -82,7 +82,7 @@ pci_type1 *pci_type1::detect() {
 
 int pci_type1::read_config_byte(const pci_location_t state, uint32_t reg, uint8_t *value) {
     LTRACEF_LEVEL(2, "state bus %#hhx dev %#hhx %#hhx reg %#x\n", state.bus, state.dev, state.fn, reg);
-    *value = type1_read_half(state.bus, state.dev, state.fn, reg);
+    *value = type1_read_byte(state.bus, state.dev, state.fn, reg);
     return NO_ERROR;
 }
 


### PR DESCRIPTION
It should invoke type1_read_byte() rather than type1_read_half().