### PR TITLE
[platform] [riscv-virt] Fix PLIC_PRIORITY macro

### DIFF
--- a/platform/qemu-virt-riscv/plic.c
+++ b/platform/qemu-virt-riscv/plic.c
@@ -20,7 +20,7 @@
 #define LOCAL_TRACE 0
 
 // Driver for PLIC implementation for qemu riscv virt machine
-#define PLIC_PRIORITY(irq) (PLIC_BASE_VIRT + 4 + 4 * (irq))
+#define PLIC_PRIORITY(irq) (PLIC_BASE_VIRT + 4 * (irq))
 #define PLIC_PENDING(irq)  (PLIC_BASE_VIRT + 0x1000 + (4 * ((irq) / 32)))
 #define PLIC_ENABLE(irq, hart)      (PLIC_BASE_VIRT + 0x2000 + (0x80 * PLIC_HART_IDX(hart)) + (4 * ((irq) / 32)))
 #define PLIC_THRESHOLD(hart)        (PLIC_BASE_VIRT + 0x200000 + (0x1000 * PLIC_HART_IDX(hart)))


### PR DESCRIPTION
Old PLIC_PRIORITY macro had an off-by-one bug, causing you to set the priority for the wrong IRQ.