### PR TITLE
Don't notify IRC on pushes to forks

### DIFF
--- a/.github/workflows/notify-irc.yml
+++ b/.github/workflows/notify-irc.yml
@@ -4,6 +4,7 @@ on: [push, pull_request, create]
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.repository == 'littlekernel/lk'
     steps:
       - name: irc push
         uses: rectalogic/notify-irc@v1


### PR DESCRIPTION
I just noticed that pushing to my fork sent messages to IRC - this could be quite spammy, so restrict this action to the main repository.