### PR TITLE
[arch][arm-m] simplify context switch

### DIFF
--- a/arch/arm/arm-m/arch.c
+++ b/arch/arm/arm-m/arch.c
@@ -158,7 +158,7 @@ void arm_cm_irq_exit(bool reschedule) {
     target_set_debug_led(1, false);
 
     if (reschedule)
-        arm_cm_trigger_preempt();
+        thread_preempt();
 
     KEVLOG_IRQ_EXIT(__get_IPSR());
 

--- a/arch/arm/arm-m/exceptions.c
+++ b/arch/arm/arm-m/exceptions.c
@@ -116,10 +116,10 @@ void _nmi(void) {
  */
 #if     (__CORTEX_M >= 0X03) || (__CORTEX_SC >= 300)
 #define PUSH_REGS \
-        "push	{r4-r11};"
+        "push	{r4-r11, lr};"
 #else
 #define PUSH_REGS \
-        "push	{r4-r7};" \
+        "push	{r4-r7, lr};" \
         "mov   r4, r8;" \
         "mov   r5, r9;" \
         "mov   r6, r10;" \
@@ -175,5 +175,10 @@ void __WEAK _systick(void) {
 
 void __WEAK _debugmonitor(void) {
     printf("debugmonitor\n");
+    platform_halt(HALT_ACTION_HALT, HALT_REASON_SW_PANIC);
+}
+
+void __WEAK _svc(void) {
+    printf("svc\n");
     platform_halt(HALT_ACTION_HALT, HALT_REASON_SW_PANIC);
 }

--- a/arch/arm/arm-m/include/arch/arch_thread.h
+++ b/arch/arm/arm-m/include/arch/arch_thread.h
@@ -13,15 +13,6 @@
 
 struct arch_thread {
     vaddr_t sp;
-    bool was_preempted;
-
-#if ARM_WITH_VFP
-    /* has this thread ever used the floating point state? */
-    bool fpused;
-
-    /* s16-s31 saved here. s0-s15, fpscr saved on exception frame */
-    float fpregs[16];
-#endif
 };
 
 #endif

--- a/arch/arm/arm-m/include/arch/arm/cm.h
+++ b/arch/arm/arm-m/include/arch/arm/cm.h
@@ -38,6 +38,7 @@
 #define SCB_DEMCR (0xE000EDFC)
 
 struct arm_cm_exception_frame {
+#if (__CORTEX_M >= 0x03)
     uint32_t r4;
     uint32_t r5;
     uint32_t r6;
@@ -46,52 +47,57 @@ struct arm_cm_exception_frame {
     uint32_t r9;
     uint32_t r10;
     uint32_t r11;
-    uint32_t r0;
-    uint32_t r1;
-    uint32_t r2;
-    uint32_t r3;
-    uint32_t r12;
-    uint32_t lr;
-    uint32_t pc;
-    uint32_t psr;
-};
-
-struct arm_cm_exception_frame_short {
-    uint32_t r0;
-    uint32_t r1;
-    uint32_t r2;
-    uint32_t r3;
-    uint32_t r12;
-    uint32_t lr;
-    uint32_t pc;
-    uint32_t psr;
-};
-
-struct arm_cm_exception_frame_long {
-    uint32_t r4;
-    uint32_t r5;
-    uint32_t r6;
-    uint32_t r7;
+#else
+    /* frame format is slightly different due to ordering of push/pops */
     uint32_t r8;
     uint32_t r9;
     uint32_t r10;
     uint32_t r11;
-    uint32_t lr;
+    uint32_t r4;
+    uint32_t r5;
+    uint32_t r6;
+    uint32_t r7;
+#endif
+    uint32_t exc_return;
     uint32_t r0;
     uint32_t r1;
     uint32_t r2;
     uint32_t r3;
     uint32_t r12;
-    uint32_t exc_lr;
+    uint32_t lr;
     uint32_t pc;
     uint32_t psr;
 };
 
-/* when fpu context save is enabled, this goes just above psr in the previous structs */
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+
+/* exception frame when fpu context save is enabled */
 struct arm_cm_exception_frame_fpu {
-    float    s[16];
+    uint32_t r4;
+    uint32_t r5;
+    uint32_t r6;
+    uint32_t r7;
+    uint32_t r8;
+    uint32_t r9;
+    uint32_t r10;
+    uint32_t r11;
+    uint32_t exc_return;
+
+    float s16_31[16];
+
+    uint32_t r0;
+    uint32_t r1;
+    uint32_t r2;
+    uint32_t r3;
+    uint32_t r12;
+    uint32_t lr;
+    uint32_t pc;
+    uint32_t psr;
+
+    float    s0_15[16];
     uint32_t fpscr;
 };
+#endif
 
 #if ARM_CM_DYNAMIC_PRIORITY_SIZE
 extern unsigned int arm_cm_num_irq_pri_bits;

--- a/arch/arm/arm-m/thread.c
+++ b/arch/arm/arm-m/thread.c
@@ -6,53 +6,40 @@
  * https://opensource.org/licenses/MIT
  */
 #include <sys/types.h>
-#include <string.h>
 #include <stdlib.h>
 #include <lk/debug.h>
 #include <lk/trace.h>
 #include <assert.h>
 #include <kernel/thread.h>
-#include <arch/arm.h>
 #include <arch/arm/cm.h>
 
 #define LOCAL_TRACE 0
-
-struct arm_cm_context_switch_frame {
-#if  (__CORTEX_M >= 0x03)
-    uint32_t r4;
-    uint32_t r5;
-    uint32_t r6;
-    uint32_t r7;
-    uint32_t r8;
-    uint32_t r9;
-    uint32_t r10;
-    uint32_t r11;
-    uint32_t lr;
-#else
-    /* frame format is slightly different due to ordering of push/pops */
-    uint32_t r8;
-    uint32_t r9;
-    uint32_t r10;
-    uint32_t r11;
-    uint32_t r4;
-    uint32_t r5;
-    uint32_t r6;
-    uint32_t r7;
-    uint32_t lr;
-#endif
-};
 
 /* macros for saving and restoring a context switch frame, depending on what version of
  * the architecture you are */
 #if  (__CORTEX_M >= 0x03)
 
 /* cortex-m3 and above (armv7-m) */
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+
+#define SAVE_REGS \
+        "tst        lr, #0x10;" /* check if thread used the FPU */ \
+        "it         eq;" \
+        "vpusheq    { s16-s31 };" /* also triggers lazy stacking of s0-s15 */ \
+        "push       { r4-r11, lr };" /* note: saves 9 words */
+#define RESTORE_REGS_PC \
+        "pop        { r4-r11, lr };" \
+        "tst        lr, #0x10;" \
+        "it         eq;" \
+        "vpopeq     { s16-s31 };" \
+        "bx         lr;"
+
+#else
+
 #define SAVE_REGS       "push   { r4-r11, lr };" /* note: saves 9 words */
-#define RESTORE_REGS    "pop    { r4-r11, lr };"
 #define RESTORE_REGS_PC "pop    { r4-r11, pc };"
-#define SAVE_SP(basereg, tempreg, offset) "str   sp, [" #basereg "," #offset "];"
-#define LOAD_SP(basereg, tempreg, offset) "ldr   sp, [" #basereg "," #offset "];"
-#define CLREX           "clrex;"
+
+#endif
 
 #else
 
@@ -64,15 +51,6 @@ struct arm_cm_context_switch_frame {
         "mov    r6, r10;" \
         "mov    r7, r11;" \
         "push   { r4-r7 };" /* note: saves 9 words */
-#define RESTORE_REGS \
-        "pop    { r4-r7 };" \
-        "mov    r8 , r4;" \
-        "mov    r9 , r5;" \
-        "mov    r10, r6;" \
-        "mov    r11, r7;" \
-        "pop    { r4-r7 };" \
-        "pop    { r0 };" \
-        "mov    lr, r0;" /* NOTE: trashes r0 */
 #define RESTORE_REGS_PC \
         "pop    { r4-r7 };" \
         "mov    r8 , r4;" \
@@ -80,20 +58,13 @@ struct arm_cm_context_switch_frame {
         "mov    r10, r6;" \
         "mov    r11, r7;" \
         "pop    { r4-r7, pc };"
-#define SAVE_SP(basereg, tempreg, offset) \
-        "mov    " #tempreg ", sp;" \
-        "str    " #tempreg ", [" #basereg "," #offset "];"
-#define LOAD_SP(basereg, tempreg, offset) \
-        "ldr    " #tempreg ", [" #basereg "," #offset "];" \
-        "mov    sp, " #tempreg ";"
-
-/* there is no clrex on armv6m devices */
-#define CLREX           ""
 
 #endif
 
 /* since we're implicitly uniprocessor, store a pointer to the current thread here */
 thread_t *_current_thread;
+
+static thread_t *_prev_running_thread = NULL;
 
 static void initial_thread_func(void) __NO_RETURN;
 static void initial_thread_func(void) {
@@ -103,10 +74,6 @@ static void initial_thread_func(void) {
 #if LOCAL_TRACE
     dump_thread(_current_thread);
 #endif
-
-    /* release the thread lock that was implicitly held across the reschedule */
-    spin_unlock(&thread_lock);
-    arch_enable_ints();
 
     ret = _current_thread->entry(_current_thread->arg);
 
@@ -121,242 +88,49 @@ void arch_thread_initialize(struct thread *t) {
     /* find the top of the stack and align it on an 8 byte boundary */
     uint32_t *sp = (void *)ROUNDDOWN((vaddr_t)t->stack + t->stack_size, 8);
 
-    struct arm_cm_context_switch_frame *frame = (void *)sp;
+    struct arm_cm_exception_frame *frame = (void *)sp;
     frame--;
 
-    /* arrange for lr to point to our starting routine */
-    frame->lr = (uint32_t)&initial_thread_func;
+    /* arrange for pc to point to our starting routine */
+    frame->pc = (uint32_t)&initial_thread_func;
+    /* set thumb mode bit */
+    frame->psr = xPSR_T_Msk;
+    /* set EXC_RETURN value to thread mode using MSP and no FP */
+    frame->exc_return = 0xfffffff9;
 
     t->arch.sp = (addr_t)frame;
-    t->arch.was_preempted = false;
-
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-    /* zero the fpu register state */
-    memset(t->arch.fpregs, 0, sizeof(t->arch.fpregs));
-    t->arch.fpused = false;
-#endif
 }
 
-static volatile struct arm_cm_exception_frame_long *preempt_frame;
-
-static void pendsv(struct arm_cm_exception_frame_long *frame) {
-    arch_disable_ints();
-
+static vaddr_t pendsv_swap_sp(vaddr_t old_frame) {
     /* make sure the stack is 8 byte aligned */
     DEBUG_ASSERT(((uintptr_t)__GET_FRAME() & 0x7) == 0);
 
     DEBUG_ASSERT_MSG(!spin_lock_held(&thread_lock),
-        "PENDSV: thread lock was held when preempted! pc %#x\n", frame->pc);
+        "PENDSV: thread lock was held when preempted! pc %#x\n", ((struct arm_cm_exception_frame *)old_frame)->pc);
 
-    LTRACEF("preempting thread %p (%s)\n", _current_thread, _current_thread->name);
+    DEBUG_ASSERT(_prev_running_thread != NULL);
+    DEBUG_ASSERT(_current_thread != NULL);
 
-    /* save the iframe the pendsv fired on and hit the preemption code */
-    preempt_frame = frame;
-    thread_preempt();
-
-    LTRACEF("fell through\n");
-
-    /* if we got here, there wasn't anything to switch to, so just fall through and exit */
-    preempt_frame = NULL;
-
-    DEBUG_ASSERT(!spin_lock_held(&thread_lock));
-
-    arch_enable_ints();
+    _prev_running_thread->arch.sp = old_frame;
+    _prev_running_thread = NULL;
+    return _current_thread->arch.sp;
 }
 
 /*
- * raw pendsv exception handler, triggered by interrupt glue to schedule
- * a preemption check.
+ * raw pendsv exception handler, triggered by arch_context_switch()
+ * to do the actual switch.
  */
 __NAKED void _pendsv(void) {
     __asm__ volatile(
         SAVE_REGS
         "mov    r0, sp;"
         "sub    sp, #4;" /* adjust the stack to be 8 byte aligned */
+        "cpsid  i;"
         "bl     %c0;"
-        "add    sp, #4;"
-        RESTORE_REGS_PC
-        :: "i" (pendsv)
-    );
-    __UNREACHABLE;
-}
-/*
- * svc handler, used to hard switch the cpu into exception mode to return
- * to preempted thread.
- */
-__NAKED void _svc(void) {
-    __asm__ volatile(
-        /* load the pointer to the original exception frame we want to restore */
-        "mov    sp, r4;"
-        RESTORE_REGS_PC
-    );
-}
-
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-__NAKED static void _half_save_and_svc(struct thread *oldthread, struct thread *newthread, bool fpu_save, bool restore_fpu)
-#else
-__NAKED static void _half_save_and_svc(struct thread *oldthread, struct thread *newthread)
-#endif
-{
-    __asm__ volatile(
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        /* see if we need to save fpu context */
-        "tst    r2, #1;"
-        "beq    0f;"
-
-        /* save part of the fpu context on the stack */
-        "vmrs   r2, fpscr;"
-        "push   { r2 };"
-        "vpush  { s0-s15 };"
-
-        /* save the top regs into the thread struct */
-        "add    r2, r0, %[fp_off];"
-        "vstm   r2, { s16-s31 };"
-
-        "0:"
-#endif
-
-        /* save regular context */
-        SAVE_REGS
-        SAVE_SP(r0, r2, %[sp_off])
-
-        /* restore the new thread's stack pointer, but not the integer state (yet) */
-        LOAD_SP(r1, r2, %[sp_off])
-
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        /* see if we need to restore fpu context */
-        "tst    r3, #1;"
-        "beq    0f;"
-
-        /* restore the top part of the fpu context */
-        "add    r3, r1, %[fp_off];"
-        "vldm   r3, { s16-s31 };"
-
-        /* restore the bottom part of the context, stored up the frame a little bit */
-        "add    r3, sp, %[fp_exc_off];"
-        "vldm   r3!, { s0-s15 };"
-        "ldr    r3, [r3];"
-        "vmsr   fpscr, r3;"
-        "b      1f;"
-
-        /* disable fpu context if we're not restoring anything */
-        "0:"
-        "mrs    r3, CONTROL;"
-        "bic    r3, #(1<<2);" /* unset FPCA */
-        "msr    CONTROL, r3;"
-        "isb;"
-
-        "1:"
-#endif
-
-        CLREX
         "cpsie  i;"
-
-        /* make a svc call to get us into handler mode.
-         * use r4 as an arg, since r0 is saved on the stack for the svc */
-        "mov    r4, sp;"
-        "svc    #0;"
-        ::  [sp_off] "i"(offsetof(thread_t, arch.sp))
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        ,[fp_off] "i"(offsetof(thread_t, arch.fpregs))
-        ,[fp_exc_off] "i"(sizeof(struct arm_cm_exception_frame_long))
-#endif
-    );
-}
-
-/* simple scenario where the to and from thread yielded */
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-__NAKED static void _arch_non_preempt_context_switch(struct thread *oldthread, struct thread *newthread, bool save_fpu, bool restore_fpu)
-#else
-__NAKED static void _arch_non_preempt_context_switch(struct thread *oldthread, struct thread *newthread)
-#endif
-{
-    __asm__ volatile(
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        /* see if we need to save fpu context */
-        "tst    r2, #1;"
-        "beq    0f;"
-
-        /* save part of the fpu context on the stack */
-        "vmrs   r2, fpscr;"
-        "push   { r2 };"
-        "vpush  { s0-s15 };"
-
-        /* save the top regs into the thread struct */
-        "add    r2, r0, %[fp_off];"
-        "vstm   r2, { s16-s31 };"
-
-        "0:"
-#endif
-
-        /* save regular context */
-        SAVE_REGS
-        SAVE_SP(r0, r2, %[sp_off])
-
-        /* restore new context */
-        LOAD_SP(r1, r2, %[sp_off])
-        RESTORE_REGS
-
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        /* see if we need to restore fpu context */
-        "tst    r3, #1;"
-        "beq    0f;"
-
-        /* restore fpu context */
-        "add    r3, r1, %[fp_off];"
-        "vldm   r3, { s16-s31 };"
-
-        "vpop   { s0-s15 };"
-        "pop    { r3 };"
-        "vmsr   fpscr, r3;"
-        "b      1f;"
-
-        /* disable fpu context if we're not restoring anything */
-        "0:"
-        "mrs    r3, CONTROL;"
-        "bic    r3, #(1<<2);" /* unset FPCA */
-        "msr    CONTROL, r3;"
-        "isb;"
-
-        "1:"
-#endif
-
-        CLREX
-        "bx     lr;"
-        ::  [sp_off] "i"(offsetof(thread_t, arch.sp))
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        , [fp_off] "i"(offsetof(thread_t, arch.fpregs))
-#endif
-    );
-}
-
-__NAKED static void _thread_mode_bounce(bool fpused) {
-    __asm__ volatile(
-        /* restore main context */
-        RESTORE_REGS
-
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        /* see if we need to restore fpu context */
-        "tst    r0, #1;"
-        "beq    0f;"
-
-        /* restore fpu context */
-        "vpop   { s0-s15 };"
-        "pop    { r0 };"
-        "vmsr   fpscr, r0;"
-        "b      1f;"
-
-        /* disable fpu context if we're not restoring anything */
-        "0:"
-        "mrs    r3, CONTROL;"
-        "bic    r3, #(1<<2);" /* unset FPCA */
-        "msr    CONTROL, r3;"
-        "isb;"
-
-        "1:"
-#endif
-
-        "bx     lr;"
+        "mov    sp, r0;"
+        RESTORE_REGS_PC
+        :: "i" (pendsv_swap_sp)
     );
     __UNREACHABLE;
 }
@@ -364,9 +138,8 @@ __NAKED static void _thread_mode_bounce(bool fpused) {
 /*
  * The raw context switch routine. Called by the scheduler when it decides to switch.
  * Called either in the context of a thread yielding or blocking (interrupts disabled,
- * on the system stack), or inside the pendsv handler on a thread that is being preempted
- * (interrupts disabled, in handler mode). If preempt_frame is set the thread
- * is being preempted.
+ * on the system stack), or at the end of an interrupt handler via thread_preempt()
+ * on a thread that is being preempted (interrupts disabled, in handler mode).
  */
 void arch_context_switch(struct thread *oldthread, struct thread *newthread) {
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
@@ -374,147 +147,64 @@ void arch_context_switch(struct thread *oldthread, struct thread *newthread) {
             FPU->FPCCR & FPU_FPCCR_LSPACT_Msk, FPU->FPCAR, __get_CONTROL() & CONTROL_FPCA_Msk);
 #endif
 
+    DEBUG_ASSERT(arch_ints_disabled());
     DEBUG_ASSERT(spin_lock_held(&thread_lock));
 
-    /* if preempt_frame is set, we are being preempted */
-    if (preempt_frame) {
-        LTRACEF("we're preempted, old frame %p, old lr 0x%x, pc 0x%x, new preempted bool %d\n",
-                preempt_frame, preempt_frame->lr, preempt_frame->pc, newthread->arch.was_preempted);
+    const bool in_interrupt_context = arch_in_int_handler();
 
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        /* see if extended fpu frame was pushed */
-        if ((preempt_frame->lr & (1<<4)) == 0) {
-            LTRACEF("thread %s pushed fpu frame\n", oldthread->name);
+    /*
+     * An interrupt handler might preempt a pending context switch,
+     * but this should never happen in thread mode.
+     */
+    DEBUG_ASSERT(in_interrupt_context || (_prev_running_thread == NULL));
 
-            /* save the top part of the context */
-            /* note this should also trigger a lazy fpu save if it hasn't already done so */
-            asm volatile("vstm %0, { s16-s31 }" :: "r" (&oldthread->arch.fpregs[0]));
-            oldthread->arch.fpused = true;
+    /*
+     * Since interrupt handlers could preempt PendSV and trigger additional
+     * switches before the first switch happens, we need to remember which
+     * thread was last running to ensure the context is saved to the correct
+     * thread struct.
+     */
+    if (_prev_running_thread == NULL) {
+        _prev_running_thread = oldthread;
 
-            /* verify that FPCCR.LSPACT was cleared and CONTROL.FPCA was set */
-            DEBUG_ASSERT((FPU->FPCCR & FPU_FPCCR_LSPACT_Msk) == 0);
-            DEBUG_ASSERT(__get_CONTROL() & CONTROL_FPCA_Msk);
-        } else {
-            DEBUG_ASSERT(oldthread->arch.fpused == false);
-        }
-#endif
-
-        oldthread->arch.was_preempted = true;
-        oldthread->arch.sp = (addr_t)preempt_frame;
-        preempt_frame = NULL;
-
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        /* if new thread has saved fpu state, restore it */
-        if (newthread->arch.fpused) {
-            LTRACEF("newthread FPCCR.LSPACT %lu, FPCAR 0x%x, CONTROL.FPCA %lu\n",
-                    FPU->FPCCR & FPU_FPCCR_LSPACT_Msk, FPU->FPCAR, __get_CONTROL() & CONTROL_FPCA_Msk);
-
-            /* enable the fpu manually */
-            __set_CONTROL(__get_CONTROL() | CONTROL_FPCA_Msk);
-            asm volatile("isb");
-
-            DEBUG_ASSERT((FPU->FPCCR & FPU_FPCCR_LSPACT_Msk) == 0);
-            DEBUG_ASSERT(__get_CONTROL() & CONTROL_FPCA_Msk);
-
-            /* restore the top of the fpu state, the rest will happen below */
-            asm volatile("vldm %0, { s16-s31 }" :: "r" (&newthread->arch.fpregs[0]));
-        }
-#endif
-
-        if (newthread->arch.was_preempted) {
-            /* return directly to the preempted thread's iframe */
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-            LTRACEF("newthread2 FPCCR.LSPACT %lu, FPCAR 0x%x, CONTROL.FPCA %lu\n",
-                    FPU->FPCCR & FPU_FPCCR_LSPACT_Msk, FPU->FPCAR, __get_CONTROL() & CONTROL_FPCA_Msk);
-#endif
-            /*
-             * We were preempted and thus came through thread_preempt() to get to here
-             * which grabbed the thread lock on the way in. We're returning to a thread that
-             * was preempted and not holding the thread lock, so drop it now.
-             */
-            arch_spin_unlock(&thread_lock);
-
-            __asm__ volatile(
-                "mov    sp, %0;"
-                "cpsie  i;"
-                CLREX
-                RESTORE_REGS_PC
-                :: "r"(newthread->arch.sp)
-            );
-            __UNREACHABLE;
-        } else {
-            /* we're inside a pendsv, switching to a user mode thread */
-            /* set up a fake frame to exception return to */
-            struct arm_cm_exception_frame_short *frame = (void *)newthread->arch.sp;
-            frame--;
-
-            frame->pc = (uint32_t)&_thread_mode_bounce;
-            frame->psr = (1 << 24); /* thread bit set, IPSR 0 */
-            frame->r0 = frame->r1 = frame->r2 = frame->r3 = frame->r12 = frame->lr = 0;
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-            /* pass the fpused bool to _thread_mode_bounce */
-            frame->r0 = newthread->arch.fpused;
-#endif
-
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-            LTRACEF("iretting to user space, fpused %u\n", newthread->arch.fpused);
-#else
-            LTRACEF("iretting to user space\n");
-#endif
-
-            __asm__ volatile(
-                CLREX
-                "mov    sp, %0;"
-                "bx     %1;"
-                :: "r"(frame), "r"(0xfffffff9)
-            );
-            __UNREACHABLE;
-        }
-    } else {
-        oldthread->arch.was_preempted = false;
-
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        /* see if we have fpu state we need to save */
-        if (!oldthread->arch.fpused && __get_CONTROL() & CONTROL_FPCA_Msk) {
-            /* mark this thread as using float */
-            LTRACEF("thread %s uses float\n", oldthread->name);
-            oldthread->arch.fpused = true;
-        }
-#endif
-
-        if (newthread->arch.was_preempted) {
-            LTRACEF("not being preempted, but switching to preempted thread\n");
-
-            /* The thread lock is held now because we entered via a normal reschedule
-             * (ie, not a preemption). We're returning directly to a thread that was preempted
-             * so drop the thread lock now.
-             */
-            arch_spin_unlock(&thread_lock);
-
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-            _half_save_and_svc(oldthread, newthread, oldthread->arch.fpused, newthread->arch.fpused);
-#else
-            _half_save_and_svc(oldthread, newthread);
-#endif
-        } else {
-            /* fast path, both sides did not preempt */
-            LTRACEF("both sides are not preempted newsp 0x%lx\n", newthread->arch.sp);
-#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-            _arch_non_preempt_context_switch(oldthread, newthread, oldthread->arch.fpused, newthread->arch.fpused);
-#else
-            _arch_non_preempt_context_switch(oldthread, newthread);
-#endif
-        }
+        /*
+         * Only trigger preempt if a context switch was not already pending.
+         * This prevents a race where another interrupt could preempt PendSV
+         * after it has started running, but before it has done the sp swap,
+         * and mark it pending again, which could lead to a tail chained
+         * second call to _pendsv() with _prev_running_thread set to NULL.
+         */
+        arm_cm_trigger_preempt();
     }
 
+    if (!in_interrupt_context) {
+        /* we're in thread context, so jump to PendSV immediately */
+
+        /* drop the lock and enable interrupts so PendSV can run */
+        spin_unlock(&thread_lock);
+        arch_enable_ints();
+
+        /* should jump to PendSV here */
+
+        arch_disable_ints();
+        spin_lock(&thread_lock);
+    } else {
+        /*
+         * If we're in interrupt context, then we've come through
+         * thread_preempt() from arm_cm_irq_exit(). The switch will happen when
+         * the current handler exits and tail-chains to PendSV.
+         */
+    }
 }
 
 void arch_dump_thread(thread_t *t) {
     if (t->state != THREAD_RUNNING) {
         dprintf(INFO, "\tarch: ");
-        dprintf(INFO, "sp 0x%lx, was preempted %u", t->arch.sp, t->arch.was_preempted);
+        dprintf(INFO, "sp 0x%lx", t->arch.sp);
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-        dprintf(INFO, ", fpused %u", t->arch.fpused);
+        const struct arm_cm_exception_frame *frame = (struct arm_cm_exception_frame *)t->arch.sp;
+        const bool fpused = (frame->exc_return & 0x10) == 0;
+        dprintf(INFO, ", fpused %u", fpused);
 #endif
         dprintf(INFO, "\n");
     }

--- a/arch/arm/include/arch/arch_ops.h
+++ b/arch/arm/include/arch/arch_ops.h
@@ -14,7 +14,7 @@
 #include <lk/reg.h>
 #include <arch/arm.h>
 
-#if ARM_ISA_ARMV7M
+#if ARM_ISA_ARMV7M || ARM_ISA_ARMV6M
 #include <arch/arm/cm.h>
 #endif
 
@@ -173,6 +173,12 @@ static inline bool arch_ints_disabled(void) {
     __asm__ volatile("mrs %0, primask" : "=r"(state));
     state &= 0x1;
     return !!state;
+}
+
+static inline bool arch_in_int_handler(void) {
+    uint32_t ipsr;
+    __asm volatile ("MRS %0, ipsr" : "=r" (ipsr) );
+    return (ipsr & IPSR_ISR_Msk);
 }
 
 static inline ulong arch_cycle_count(void) {


### PR DESCRIPTION
The context switch is now always performed inside the PendSV handler, which greatly simplifies the code by reducing all switches to a single path. This should also eliminate any race conditions during the switch.

Because we always enter PendSV for a switch, there is a slight performance penalty in the case of switching from a non-preempted thread to another non-preempted thread (~40 cycles longer on an M4, compared to the previous implementation)