### PR TITLE
[arch][arm64] Fix mmu_unmap issue when FEAT_TTL is implemented

### DIFF
--- a/arch/arm64/mmu.c
+++ b/arch/arm64/mmu.c
@@ -8,6 +8,7 @@
 
 #include <arch/arm64/mmu.h>
 #include <assert.h>
+#include <lk/bits.h>
 #include <lk/debug.h>
 #include <lk/err.h>
 #include <kernel/vm.h>
@@ -356,9 +357,9 @@ static void arm64_mmu_unmap_pt(vaddr_t vaddr, vaddr_t vaddr_rel,
             page_table[index] = MMU_PTE_DESCRIPTOR_INVALID;
             CF;
             if (asid == MMU_ARM64_GLOBAL_ASID)
-                ARM64_TLBI(vaae1is, vaddr >> 12);
+                ARM64_TLBI(vaae1is, BITS_SHIFT(vaddr, 55, 12));
             else
-                ARM64_TLBI(vae1is, vaddr >> 12 | (vaddr_t)asid << 48);
+                ARM64_TLBI(vae1is, BITS_SHIFT(vaddr, 55, 12) | (vaddr_t)asid << 48);
         } else {
             LTRACEF("pte %p[0x%lx] already clear\n", page_table, index);
         }


### PR DESCRIPTION
Precisely set bits [55:22] of the vaddress in bits [43:0] for the vae1is and vaee1is TLBI commands.

On platforms where FEAT_TLL is implemented, bits [47:44] of the command accept a TTL parameter which can optionally be set to hint the translation table level containing the address being invalidated. Implementations aren't architecturally required to perform the invalidation if the hint is incorrect however. Invalidations may therefore fail with the current implementation if the vaddress has bits set in [58:55].

This is notably an issue on ARM fastmodels which doesn't perform the invalidation when the TTL parameter is incorrect.