### PR TITLE
[make] Add ability to deny modules from being used

### DIFF
--- a/engine.mk
+++ b/engine.mk
@@ -165,6 +165,9 @@ BUILDID ?=
 # comment out or override if you want to see the full output of each command
 NOECHO ?= @
 
+# Any modules you want to explictly prevent from being used
+DENY_MODULES :=
+
 # try to include the project file
 -include project/$(PROJECT).mk
 ifndef TARGET

--- a/make/module.mk
+++ b/make/module.mk
@@ -46,6 +46,10 @@ $(error MODULE $(MODULE) is probably setting OBJS, change to MODULE_SRCS)
 endif
 endif
 
+ifneq ($(filter $(MODULE),$(DENY_MODULES)),)
+$(error MODULE $(MODULE) is not allowed by PROJECT $(PROJECT)'s DENY_MODULES list)
+endif
+
 MODULE_SRCDIR := $(MODULE)
 MODULE_BUILDDIR := $(call TOBUILDDIR,$(MODULE_SRCDIR))
 


### PR DESCRIPTION
Certain projects may want to prevent the usage of certain modules from being used. Here are two examples of when this may occur:

1. The Project has it's own fdt library and does not want developer's using the version of libfdt included with LK

2. The project does not want developers using mincrypt.

`DENY_MODULES` is a list which developers can set in their own project makefiles which is checked on each module inclusion. If that module is on the deny list, it causes a build failure.