### PR TITLE
[console] Flag to disable default console output

### DIFF
--- a/lib/io/console.c
+++ b/lib/io/console.c
@@ -59,10 +59,12 @@ static void out_count(const char *str, size_t len) {
         spin_unlock_restore(&print_spin_lock, state, PRINT_LOCK_FLAGS);
     }
 
+#if CONSOLE_OUTPUT_TO_PLATFORM_PUTC
     /* write out the serial port */
     for (i = 0; i < len; i++) {
         platform_dputc(str[i]);
     }
+#endif
 }
 
 void register_print_callback(print_callback_t *cb) {

--- a/lib/io/include/lib/io.h
+++ b/lib/io/include/lib/io.h
@@ -54,6 +54,11 @@ static inline void io_handle_init(io_handle_t *io, io_handle_hooks_t *hooks) {
 /* the main console io handle */
 extern io_handle_t console_io;
 
+/* should the console also output to the platform's putc (usually UART) */
+#ifndef CONSOLE_OUTPUT_TO_PLATFORM_PUTC
+#define CONSOLE_OUTPUT_TO_PLATFORM_PUTC 1
+#endif
+
 #ifndef CONSOLE_HAS_INPUT_BUFFER
 #define CONSOLE_HAS_INPUT_BUFFER 0
 #endif


### PR DESCRIPTION
Introduces a flag which allows a project to disable the default output to platform_dputc. This is useful is the project wants to maintain `platform_dputc` for panic conditions but otherwise use a registered callback for console io.

Change-Id: I1362529a6bb40d191ac3f7c6069985c371d9284c