### PR TITLE
Let 32bit machines with limited memory size to use ubsan friendly

### DIFF
--- a/app/tests/v9fs_tests.c
+++ b/app/tests/v9fs_tests.c
@@ -43,7 +43,7 @@ int v9fs_tests(int argc, const console_cmd_args *argv) {
 
     readbytes = fs_read_file(handle, buf, 0, BUF_SIZE);
     if (readbytes < 0) {
-        LOGF("failed to read the target file: %ld\n", readbytes);
+        LOGF("failed to read the target file: %zd\n", readbytes);
         return status;
     }
 

--- a/arch/arm/arm/debug.c
+++ b/arch/arm/arm/debug.c
@@ -165,7 +165,7 @@ static int cmd_dcc(int argc, const console_cmd_args *argv) {
         uint32_t buf[128];
 
         ssize_t len = arm_dcc_read(buf, sizeof(buf), 1000);
-        printf("arm_dcc_read returns %ld\n", len);
+        printf("arm_dcc_read returns %zd\n", len);
         if (len > 0) {
             hexdump(buf, len);
         }
@@ -181,4 +181,3 @@ STATIC_COMMAND_START
 STATIC_COMMAND("dcc", "dcc stuff", &cmd_dcc)
 #endif
 STATIC_COMMAND_END(dcc);
-

--- a/external/arch/arm/arm-m/CMSIS/Include/cmsis_gcc.h
+++ b/external/arch/arm/arm-m/CMSIS/Include/cmsis_gcc.h
@@ -27,6 +27,7 @@
 
 /* LK: include lk's compiler.h first, which has some of the same #defines */
 #include <lk/compiler.h>
+__BEGIN_CDECLS
 
 /* ignore some GCC warnings */
 #pragma GCC diagnostic push
@@ -2211,4 +2212,5 @@ __STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
 
 #pragma GCC diagnostic pop
 
+__END_CDECLS
 #endif /* __CMSIS_GCC_H */

--- a/lib/bio/debug.c
+++ b/lib/bio/debug.c
@@ -125,7 +125,7 @@ usage:
             ssize_t err_len = bio_read(dev, buf, offset, amt);
 
             if (err_len < 0) {
-                dprintf(ALWAYS, "read error %s %zu@%zu (err_len %ld)\n",
+                dprintf(ALWAYS, "read error %s %zu@%zu (err_len %zd)\n",
                         argv[2].str, amt, (size_t)offset, err_len);
                 break;
             }
@@ -413,7 +413,7 @@ static status_t memory_mapped_test(bdev_t *device) {
     // Erase the first page of the Device.
     ssize_t err = bio_erase(device, 0, device->block_size);
     if (err < (ssize_t)device->block_size) {
-        printf("Expected to erase at least %zu bytes but only erased %ld. "
+        printf("Expected to erase at least %zu bytes but only erased %zd. "
                "Not continuing to test memory mapped mode.\n",
                device->block_size, err);
         retcode = ERR_IO;
@@ -430,7 +430,7 @@ static status_t memory_mapped_test(bdev_t *device) {
     err = bio_write_block(device, test_buffer, 0, 1);
     if (err != (ssize_t)device->block_size) {
         printf("Error while writing test pattern to device. Expected to write "
-               "%zu bytes but actually wrote %ld. Not continuing to test memory "
+               "%zu bytes but actually wrote %zd. Not continuing to test memory "
                "mapped mode.\n", device->block_size, err);
         retcode = ERR_IO;
         goto finish;
@@ -474,7 +474,7 @@ static status_t memory_mapped_test(bdev_t *device) {
     // what we wrote back earlier.
     err = bio_read_block(device, reference_buffer, 0, 1);
     if (err != (ssize_t)device->block_size) {
-        printf("Expected to read %zu bytes, actually read %ld. Aborting.\n",
+        printf("Expected to read %zu bytes, actually read %zd. Aborting.\n",
                device->block_size, err);
         retcode = ERR_IO;
         goto finish;
@@ -501,10 +501,10 @@ finish:
 static int bio_test_device(bdev_t *device) {
     ssize_t num_errors = erase_test(device);
     if (num_errors < 0) {
-        printf("error %ld performing erase test\n", num_errors);
+        printf("error %zd performing erase test\n", num_errors);
         return -1;
     }
-    printf("discovered %ld error(s) while testing erase.\n", num_errors);
+    printf("discovered %zd error(s) while testing erase.\n", num_errors);
     if (num_errors) {
         // No point in continuing the tests if we couldn't erase the device.
         printf("not continuing to test writes.\n");
@@ -512,7 +512,7 @@ static int bio_test_device(bdev_t *device) {
     }
 
     num_errors = write_test(device);
-    printf("Discovered %ld error(s) while testing write.\n", num_errors);
+    printf("Discovered %zd error(s) while testing write.\n", num_errors);
     if (num_errors) {
         return -1;
     }

--- a/lib/fs/9p/dir.c
+++ b/lib/fs/9p/dir.c
@@ -268,7 +268,7 @@ status_t v9fs_read_dir(dircookie *dcookie, struct dirent *ent)
             }
 
             LTRACEF(
-                "head (%u) tail (%u) sread (%ld) offset (%llu) name "
+                "head (%u) tail (%u) sread (%zd) offset (%llu) name "
                 "(%s)\n",
                 dir->head, dir->tail, sread, p9_dent.offset, p9_dent.name);
 

--- a/lib/fs/spifs/test/spifstest.c
+++ b/lib/fs/spifs/test/spifstest.c
@@ -731,7 +731,7 @@ static int spifs_bench(int argc, const console_cmd_args *argv) {
 
         if (n_bytes < 0) {
             printf("SPIFS Benchmark Failed to write to file at %s. "
-                   "Reason = %ld.\n", test_file_path, n_bytes);
+                   "Reason = %zd.\n", test_file_path, n_bytes);
             retcode = -1;
             fs_close_file(handle);
             goto finish;
@@ -752,7 +752,7 @@ static int spifs_bench(int argc, const console_cmd_args *argv) {
 
         if (n_bytes < 0) {
             printf("SPIFS Benchmark Failed to read from file at %s. "
-                   "Reason = %ld.\n", test_file_path, n_bytes);
+                   "Reason = %zd.\n", test_file_path, n_bytes);
             retcode = -1;
             fs_close_file(handle);
             goto finish;

--- a/lib/libc/include/sys/types.h
+++ b/lib/libc/include/sys/types.h
@@ -44,7 +44,11 @@ enum handler_return {
     INT_RESCHEDULE,
 };
 
+#ifdef __LP64__
 typedef signed long int ssize_t;
+#else
+typedef signed int ssize_t;
+#endif
 
 typedef uint8_t u8;
 typedef uint16_t u16;

--- a/lib/minip/tcp.c
+++ b/lib/minip/tcp.c
@@ -1330,7 +1330,7 @@ usage:
             uint8_t buf[512];
 
             ssize_t err_len = tcp_read(accepted, buf, sizeof(buf));
-            printf("tcp_read returns %ld\n", err_len);
+            printf("tcp_read returns %zd\n", err_len);
             if (err_len < 0)
                 break;
             if (err_len > 0) {
@@ -1338,7 +1338,7 @@ usage:
             }
 
             err_len = tcp_write(accepted, buf, err_len);
-            printf("tcp_write returns %ld\n", err_len);
+            printf("tcp_write returns %zd\n", err_len);
             if (err_len < 0)
                 break;
         }
@@ -1362,4 +1362,3 @@ usage:
 STATIC_COMMAND_START
 STATIC_COMMAND("tcp", "tcp commands", &cmd_tcp)
 STATIC_COMMAND_END(tcp);
-

--- a/lib/minip/udp.c
+++ b/lib/minip/udp.c
@@ -148,7 +148,7 @@ status_t udp_send_iovec(const iovec_t *iov, uint iov_count, udp_socket_t *handle
     udp->chksum = rfc768_chksum(ip, udp);
 #endif
 
-    LTRACEF("packet paylod len %ld\n", len);
+    LTRACEF("packet paylod len %zd\n", len);
 
     minip_tx_handler(minip_tx_arg, p);
 

--- a/lib/test_ubsan/rules.mk
+++ b/lib/test_ubsan/rules.mk
@@ -1,0 +1,14 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+MODULE := $(LOCAL_DIR)
+
+MODULE_SRCS += \
+	$(LOCAL_DIR)/test_ubsan.c \
+	$(LOCAL_DIR)/test_ubsan.cpp
+
+MODULE_DEPS += \
+	lib/ubsan
+
+MODULE_COMPILEFLAGS += -fsanitize=undefined
+
+include make/module.mk

--- a/lib/test_ubsan/test_ubsan.c
+++ b/lib/test_ubsan/test_ubsan.c
@@ -1,0 +1,296 @@
+// Copyright 2024, Google LLC
+
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <lk/console_cmd.h>
+#include <lk/err.h>
+#include <lk/utils.h>
+
+#define TESTCASE_UBSAN(x) { .func = x, .name = #x }
+
+typedef void (*test_ubsan_fp)(void);
+struct test_ubsan_struct {
+    test_ubsan_fp func;
+    const char *const name;
+};
+
+static void add_overflow(void) {
+    volatile int val = INT_MAX;
+    volatile int val2 = 1;
+
+    val += val2;
+}
+
+static void sub_overflow(void) {
+    volatile int val = INT_MIN;
+    volatile int val2 = 1;
+
+    val -= val2;
+}
+
+static void mul_overflow(void) {
+    volatile int val = INT_MAX / 2;
+    volatile int val2 = 3;
+
+    val *= val2;
+}
+
+static void negate_overflow(void) {
+    volatile int val = INT_MIN;
+
+    val = -val;
+}
+
+static void divrem_overflow(void) {
+    volatile int val = 16;
+    volatile int val2 = 0;
+
+    val /= val2;
+}
+
+static void pointer_overflow(void) {
+    volatile uintptr_t offset = UINTPTR_MAX;
+    char buf[4];
+    char *ptr = buf;
+
+    ptr += offset;
+    (void) ptr;
+}
+
+static void float_cast_overflow(void) {
+    volatile uint32_t val;
+    volatile uint32_t mul = 10;
+
+    val =  mul * 0xFFFF * 1e9;
+    (void) val;
+}
+
+static void shift_out_of_bounds_overflow(void) {
+    volatile int pos = 1;
+    volatile int val = INT_MAX;
+
+    val <<= pos;
+}
+
+static void shift_out_of_bounds_negative(void) {
+    volatile int neg = -1;
+    volatile int val = 10;
+
+    val <<= neg;
+}
+
+static void out_of_bounds_overflow(void) {
+    volatile int val = 10;
+    volatile int overflow = 4;
+    volatile char above[4] = {};
+    volatile int arr[4];
+    volatile char below[4] = {};
+
+    above[0] = below[0];
+    arr[overflow] = val;
+}
+
+static void out_of_bounds_underflow(void) {
+    volatile int val = 10;
+    volatile int underflow = -1;
+    volatile char above[4] = {};
+    volatile int arr[4];
+    volatile char below[4] = {};
+
+    above[0] = below[0];
+    arr[underflow] = val;
+}
+
+static void load_invalid_value_bool(void) {
+    volatile char *dst, *src;
+    bool val, val2;
+    volatile char invalid_val = 2;
+
+    src = &invalid_val;
+    dst = (char *)&val;
+    *dst = *src;
+
+    val2 = val;
+    (void) val2;
+}
+
+extern void load_invalid_value_enum(void);
+
+static void nullptr_deref(void) {
+    int *nullptr = NULL;
+    int val = *nullptr;
+    (void) val;
+}
+
+static void misaligned_access(void) {
+    struct object {
+        int val;
+    };
+    char buf[3];
+    struct object *obj = (struct object *)buf;
+
+    obj = (struct object*)(buf + 1);
+    obj->val = 0;
+}
+
+static void object_size_mismatch(void) {
+    struct object {
+        int val;
+    };
+
+    char buf[3];
+    struct object *obj = (struct object *)buf;
+
+    obj->val = 0;
+}
+
+static void func(int a) { return; }
+static void function_type_mismatch(void) {
+    typedef void (*func_ptr)(void);
+    func_ptr f = (func_ptr) func;
+    f();
+}
+
+__attribute__((nonnull)) static void _nonnull_arg( void *ptr) { (void) ptr; }
+static void nonnull_arg(void) {
+    volatile void *nullptr = NULL;
+    _nonnull_arg((void *)nullptr);
+}
+
+__attribute__((returns_nonnull)) static void* _nonnull_return(void) {
+    volatile void *ret = NULL;
+    return (void *)ret;
+}
+
+static void nonnull_return(void) {
+    _nonnull_return();
+}
+
+static void vla_bound_not_positive(void) {
+    volatile int size = 0;
+    int arr[size];
+
+    (void) arr;
+}
+
+static void *_alignment_assumption(void) __attribute__((__assume_aligned__(32)));
+static void *_alignment_assumption(void) {
+    volatile void *ptr = (void *)0x3;
+    return (void *)ptr;
+}
+
+static void *_alignment_assumption_offset(void) __attribute__((__assume_aligned__(32, 4)));
+static void *_alignment_assumption_offset(void) {
+    volatile void *ptr = (void *)0x3;
+    return (void *)ptr;
+}
+
+static void alignment_assumption(void) {
+    void *ptr;
+
+    ptr = _alignment_assumption();
+    (void) ptr;
+}
+
+static void alignment_assumption_offset(void) {
+    void *ptr;
+
+    ptr = _alignment_assumption_offset();
+    (void) ptr;
+}
+
+// __builtin_clzg and __builtin_ctzg is not support
+static void invalid_builtin_clz(void) {
+    int ret = __builtin_clz(0);
+    (void) ret;
+}
+
+static void invalid_builtin_ctz(void) {
+    int ret = __builtin_ctz(0);
+    (void) ret;
+}
+
+static void builtin_unreachable(void) {
+    __UNREACHABLE;
+}
+
+static const struct test_ubsan_struct test_ubsan_array[] = {
+    TESTCASE_UBSAN(add_overflow),
+    TESTCASE_UBSAN(sub_overflow),
+    TESTCASE_UBSAN(mul_overflow),
+    TESTCASE_UBSAN(negate_overflow),
+    TESTCASE_UBSAN(pointer_overflow),
+    TESTCASE_UBSAN(float_cast_overflow),
+    TESTCASE_UBSAN(shift_out_of_bounds_overflow),
+    TESTCASE_UBSAN(shift_out_of_bounds_negative),
+    TESTCASE_UBSAN(out_of_bounds_overflow),
+    TESTCASE_UBSAN(out_of_bounds_underflow),
+    TESTCASE_UBSAN(load_invalid_value_bool),
+    TESTCASE_UBSAN(load_invalid_value_enum),
+    TESTCASE_UBSAN(nullptr_deref),
+    TESTCASE_UBSAN(misaligned_access),
+    TESTCASE_UBSAN(object_size_mismatch),
+    TESTCASE_UBSAN(function_type_mismatch),
+    TESTCASE_UBSAN(nonnull_arg),
+    TESTCASE_UBSAN(nonnull_return),
+    TESTCASE_UBSAN(vla_bound_not_positive),
+    TESTCASE_UBSAN(alignment_assumption),
+    TESTCASE_UBSAN(alignment_assumption_offset),
+    TESTCASE_UBSAN(invalid_builtin_clz),
+    TESTCASE_UBSAN(invalid_builtin_ctz),
+    TESTCASE_UBSAN(builtin_unreachable),
+};
+
+
+static void show_usage(void) {
+        printf("Usage: test_ubsan [OPTION]\n");
+        printf("    NUM - The testcase number you want to test\n");
+        printf("    all - executing all ubsan test cases\n");
+        printf("Available ubsan test cases:\n");
+        printf("Num: testcase name\n");
+        for (unsigned int i = 0; i < ARRAY_SIZE(test_ubsan_array); ++i)
+            printf("%3u: %s\n", i, test_ubsan_array[i].name);
+}
+
+static int test_ubsan(int argc, const console_cmd_args *argv) {
+
+    unsigned long id;
+
+    if (argc != 2) {
+        show_usage();
+        return  argc == 1 ? NO_ERROR : ERR_INVALID_ARGS;
+    }
+
+    if (!strcmp(argv[1].str, "all")) {
+        for (unsigned int i = 0; i < ARRAY_SIZE(test_ubsan_array); ++i) {
+            printf("start %s ...\n", test_ubsan_array[i].name);
+            test_ubsan_array[i].func();
+        }
+
+        return NO_ERROR;
+    }
+
+    if (!isdigit(argv[1].str[0])) {
+        show_usage();
+        return ERR_INVALID_ARGS;
+    }
+
+    id = argv[1].u;
+
+    if (id >= ARRAY_SIZE(test_ubsan_array)) {
+        show_usage();
+        return ERR_INVALID_ARGS;
+    }
+
+    printf("start %s ...\n", test_ubsan_array[id].name);
+    test_ubsan_array[id].func();
+    return NO_ERROR;
+}
+
+STATIC_COMMAND_START
+STATIC_COMMAND("test_ubsan", "testing ubsan", test_ubsan)
+STATIC_COMMAND_END(test_ubsan);

--- a/lib/test_ubsan/test_ubsan.cpp
+++ b/lib/test_ubsan/test_ubsan.cpp
@@ -1,0 +1,13 @@
+extern "C"
+{
+
+// https://cplusplus.github.io/CWG/issues/1766.html
+// It is only since C++17 that loading an out-of-range value for an enum is undefined behavior.
+// But clang treats this as UB even with C++14(LK compiles C++ files with --std=c++14 by default)
+void load_invalid_value_enum(void) {
+    enum E {e1, e2, e3, e4};
+    volatile int a = 5;
+    volatile enum E e = *((volatile enum E*)(&a));
+    (void) &e;
+}
+}


### PR DESCRIPTION
This patch series let 32 bit machines with limited memory size can use ubsan firendly.
Provide some changes as below:

1. Fix ssize_t compilation error with 32 bit machine
2. Fix compilation error which include arm cmsis with C++
3. Add some ubsan handlers which didn't exist yet.
4. Add test_ubsan for testing.
becasue ubsan may cause out of memory limiation in compilcation time.
So add a module only for testing ubsan.