### PR TITLE
[vscode] Update workspace file to better respect local style

### DIFF
--- a/lk.code-workspace
+++ b/lk.code-workspace
@@ -1,21 +1,34 @@
 {
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"settings": {
-		"editor.tabSize": 4,
-		"files.exclude": {
-			"**/.cache": true,
-			"**/.clangd": true
-		}
-	},
-	"extensions": {
-		"recommendations": [
-			"mkornelsen.vscode-arm64",
-			"llvm-vs-code-extensions.vscode-clangd",
-			"sunshaoce.risc-v"
-		]
-	}
+    "folders": [
+        {
+            "path": "."
+        }
+    ],
+    "settings": {
+        // Disable auto-formatting till the project decides on a
+        // machine-readable config to control it (e.g., .clang-format).
+        "[c]": {
+            "editor.formatOnSave": false,
+        },
+        "[cpp]": {
+            "editor.formatOnSave": false,
+        },
+        // Allows editor.tabSize to be specified (otherwise it is overridden as
+        // auto-detected).
+        "editor.detectIndentation": false,
+        // Convert tabs to spaces.
+        "editor.insertSpaces": true,
+        "editor.tabSize": 4,
+        "files.exclude": {
+            "**/.cache": true,
+            "**/.clangd": true
+        }
+    },
+    "extensions": {
+        "recommendations": [
+            "mkornelsen.vscode-arm64",
+            "llvm-vs-code-extensions.vscode-clangd",
+            "sunshaoce.risc-v"
+        ]
+    }
 }


### PR DESCRIPTION
This change updates lk.code-workspace to specify
* editor.detectIndentation as false, as otherwise that overrides the desired editor.tabSize setting.
* editor.insertSpaces as true, since spaces are preferred over tabs in the current local style
* editor.formatOnSave as false for C and C++ files, as - in the absence of a .clang-format file - the clangd extension is likely to default to choices that don't respect the local style.