### PR TITLE
[arch][arm] Enable distributor with ARE, group 1

### DIFF
--- a/arch/arm64/arch.c
+++ b/arch/arm64/arch.c
@@ -27,6 +27,13 @@ static spin_lock_t arm_boot_cpu_lock = 1;
 static volatile int secondaries_to_init = 0;
 #endif
 
+/* Defined in start.S. */
+extern uint64_t arm64_boot_el;
+
+uint64_t arm64_get_boot_el(void) {
+    return arm64_boot_el >> 2;
+}
+
 static void arm64_cpu_early_init(void) {
     /* set the vector base */
     ARM64_WRITE_SYSREG(VBAR_EL1, (uint64_t)&arm64_exception_base);
@@ -88,6 +95,8 @@ void arch_init(void) {
     /* flush the release of the lock, since the secondary cpus are running without cache on */
     arch_clean_cache_range((addr_t)&arm_boot_cpu_lock, sizeof(arm_boot_cpu_lock));
 #endif
+
+    LTRACEF("ARM boot EL%llu\n", arm64_get_boot_el());
 }
 
 void arch_quiesce(void) {

--- a/arch/arm64/asm.S
+++ b/arch/arm64/asm.S
@@ -84,7 +84,7 @@ FUNCTION(arm64_elX_to_el1)
     cmp x4, #(0b01 << 2)
     bne .notEL1
     /* Already in EL1 */
-    ret 
+    ret
 
 .notEL1:
     cmp x4, #(0b10 << 2)

--- a/arch/arm64/include/arch/arm64.h
+++ b/arch/arm64/include/arch/arm64.h
@@ -34,6 +34,8 @@ __BEGIN_CDECLS
 
 void arm64_context_switch(vaddr_t *old_sp, vaddr_t new_sp);
 
+uint64_t arm64_get_boot_el(void);
+
 /* exception handling */
 struct arm64_iframe_long {
     uint64_t r[30];
@@ -81,6 +83,15 @@ void arm64_syscall(struct arm64_iframe_long *iframe, bool is_64bit);
 void arm64_local_invalidate_cache_all(void);
 void arm64_local_clean_invalidate_cache_all(void);
 void arm64_local_clean_cache_all(void);
+
+/* Current Exception Level values, as contained in CurrentEL */
+#define CurrentEL_EL1    (1 << 2)
+#define CurrentEL_EL2    (2 << 2)
+
+static inline bool arm64_is_kernel_in_hyp_mode(void) {
+    return ARM64_READ_SYSREG(CURRENTEL) == CurrentEL_EL2;
+}
+
 
 __END_CDECLS
 

--- a/dev/interrupt/arm_gic/arm_gic_common.h
+++ b/dev/interrupt/arm_gic/arm_gic_common.h
@@ -230,6 +230,26 @@ GEN_CP15_REG64_FUNCS(icc_sgi0r_el1, 2, c12);
 #define GICD_MIN_SIZE           (GICD_LIMIT - GICD_OFFSET)
 #endif /* GIC_VERSION <= 2 */
 
+/* GICD_CTRL  Register
+ *            Non-Secure   Only_a_Single   two_Security
+ * (1U << 8)  RES0         nASSGIreq       RES0
+ * (1U << 7)  RES0         E1NWF           E1NWF
+ * (1U << 5)  RES0         RES0            ARE_NS
+ * (1U << 4)  ARE_NS       ARE             ARE_S
+ * (1U << 2)  RES0         RES0            ENABLE_G1S
+ * (1U << 1)  ENABLE_G1A   ENABLE_G1       ENABLE_G1NS
+ * (1U << 0)  ENABLE_G1    ENABLE_G0       ENABLE_G0
+ */
+#define GICD_CTLR_RWP           (1U << 31)
+#define GICD_CTLR_nASSGIreq     (1U << 8)
+#define GICD_CTRL_E1NWF         (1U << 7)
+#define GICD_CTLR_DS            (1U << 6)
+#define GICD_CTLR_ARE_NS        (1U << 5)
+#define GICD_CTLR_ARE_S         (1U << 4)
+#define GICD_CTLR_ENABLE_G1S    (1U << 2)
+#define GICD_CTLR_ENABLE_G1NS   (1U << 1)
+#define GICD_CTLR_ENABLE_G0     (1U << 0)
+
 #if GIC_VERSION > 2
 /* some registers of GICD are 64 bit */
 #define GICDREG_READ64(gic, reg) ({ \


### PR DESCRIPTION
Refering Zircon's 'gic_init' function, enable ARE and Group 1 added.
For arm_generic_timer configuration, 'arm64_get_boot_el' and 'arm64_is_kernel_in_hyp_mode' added to make decision for the hypervisor/virtual timer irq.