### PR TITLE
[kernel][port] add a missing THREAD_UNLOCK call in port_group_remove()

### DIFF
--- a/kernel/port.c
+++ b/kernel/port.c
@@ -351,8 +351,10 @@ status_t port_group_remove(port_t group, port_t port) {
         }
     }
 
-    if (!found)
+    if (!found) {
+        THREAD_UNLOCK(state);
         return ERR_BAD_HANDLE;
+    }
 
     list_delete(&rp->g_node);
 


### PR DESCRIPTION
port_group_remove() used to return without unlocking a thread if no matching read port is found, which is not correct. This patch adds a call to THREAD_UNLOCK before it returns ERR_BAD_HANDLE.