### PR TITLE
Various minor warning fixes for RISC-V Clang builds

### DIFF
--- a/arch/riscv/include/arch/riscv.h
+++ b/arch/riscv/include/arch/riscv.h
@@ -180,7 +180,7 @@ __BEGIN_CDECLS
 
 #define riscv_csr_write(csr, val) \
 ({ \
-    ulong __val = (ulong)val; \
+    ulong __val = (ulong)(val); \
     __asm__ volatile( \
         "csrw   " __ASM_STR(csr) ", %0" \
         :: "rK" (__val) \

--- a/arch/riscv/include/arch/riscv.h
+++ b/arch/riscv/include/arch/riscv.h
@@ -134,7 +134,8 @@
 #define RISCV_EXCEPTION_STORE_PAGE_FAULT    15
 
 #ifndef ASSEMBLY
-#define __ASM_STR(x)    #x
+#define ___ASM_STR(x)    #x
+#define __ASM_STR(x)    ___ASM_STR(x)
 
 __BEGIN_CDECLS
 

--- a/arch/riscv/include/arch/riscv/feature.h
+++ b/arch/riscv/include/arch/riscv/feature.h
@@ -9,6 +9,7 @@
 
 #include <lk/compiler.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 __BEGIN_CDECLS

--- a/dev/bus/pci/debug.cpp
+++ b/dev/bus/pci/debug.cpp
@@ -22,7 +22,7 @@
  */
 static void pci_list(void) {
     pci_location_t state;
-    int busses = 0, devices = 0, lines = 0, ret;
+    int busses = 0, devices = 0, ret;
 
     printf("Scanning (brute force)...\n");
 
@@ -59,7 +59,6 @@ static void pci_list(void) {
                                config.vendor_id, config.device_id, config.header_type, config.base_class,
                                config.sub_class, config.program_interface, config.type0.interrupt_line);
                         devices++;
-                        lines++;
                     }
 
                     if ((fn == 0) && ~config.header_type & PCI_HEADER_TYPE_MULTI_FN) {

--- a/external/lib/heap/dlmalloc/dlmalloc.c
+++ b/external/lib/heap/dlmalloc/dlmalloc.c
@@ -5425,7 +5425,7 @@ struct mallinfo dlmallinfo(void) {
 #endif /* NO_MALLINFO */
 
 #if !NO_MALLOC_STATS
-void dlmalloc_stats() {
+void dlmalloc_stats(void) {
   internal_malloc_stats(gm);
 }
 #endif /* NO_MALLOC_STATS */

--- a/lib/libcpp/include/type_traits
+++ b/lib/libcpp/include/type_traits
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <lk/compiler.h>
+
 namespace std {
 
 template <typename T, T v>
@@ -331,7 +333,11 @@ struct has_virtual_destructor : public integral_constant<bool, __has_virtual_des
 
 // has_trivial_destructor
 template <typename T>
+#if __has_builtin(__is_trivially_destructible)
+struct has_trivial_destructor : public integral_constant<bool, __is_trivially_destructible(T)> { };
+#else
 struct has_trivial_destructor : public integral_constant<bool, __has_trivial_destructor(T)> { };
+#endif
 
 // is_pointer
 namespace internal {


### PR DESCRIPTION
I noticed a few warnings while building RISC-V with LLVM 17, this PR should fix them.