### PR TITLE
[lib][uefi] fix a few warnings and a little code tidying

### DIFF
--- a/lib/uefi/runtime_service_provider.cpp
+++ b/lib/uefi/runtime_service_provider.cpp
@@ -21,6 +21,8 @@
 #include <stdio.h>
 #include <string.h>
 
+namespace {
+
 constexpr auto &&kSecureBoot = L"SecureBoot";
 
 EFI_STATUS GetVariable(char16_t *VariableName, EfiGuid *VendorGuid,
@@ -61,6 +63,8 @@ EFI_STATUS SetVariable(char16_t *VariableName, EfiGuid *VendorGuid,
   printf("%s is unsupported\n", __FUNCTION__);
   return UNSUPPORTED;
 }
+
+} // namespace
 
 void setup_runtime_service_table(EfiRuntimeService *service) {
   service->GetVariable = GetVariable;

--- a/lib/uefi/switch_stack.S
+++ b/lib/uefi/switch_stack.S
@@ -14,12 +14,11 @@
  * limitations under the License.
  *
  */
- 
+
 #include <lk/asm.h>
 
-
-// int call_with_stack(void *stack, int (*fp)(), int arg1, int arg2, int arg3, int arg4);
-FUNCTION(call_with_stack)
+// int call_with_stack_asm(void *stack, int (*fp)(), int arg1, int arg2, int arg3, int arg4);
+FUNCTION(call_with_stack_asm)
 stp     fp, lr, [sp, #-16]!
 mov     fp, sp
 
@@ -38,3 +37,4 @@ mov     sp,x7
 
 ldp     fp, lr, [sp], 16
 ret     lr
+END_FUNCTION(call_with_stack_asm)

--- a/lib/uefi/switch_stack.h
+++ b/lib/uefi/switch_stack.h
@@ -15,28 +15,30 @@
  *
  */
 
+#include <lk/compiler.h>
 #include <stddef.h>
 
-#ifdef __cplusplus
-extern "C" {
+__BEGIN_CDECLS
 
-#endif
+size_t call_with_stack_asm(void *stack, const void *function, void *param1,
+                       void *param2, void *param3, void *param4);
 
-size_t call_with_stack(void *stack, int (*fp)(void *, void *), void *param1,
-                       void *param2, void *param3 = nullptr,
-                       void *param4 = nullptr);
+__END_CDECLS
 
-#ifdef __cplusplus
-}
-
-#endif
 #ifdef __cplusplus
 template <typename Function, typename P1, typename P2, typename P3, typename P4>
 size_t call_with_stack(void *stack, Function &&fp, P1 &&param1, P2 &&param2,
-                       P3 param3, P4 &&param4) {
-  return call_with_stack(
-      stack, reinterpret_cast<int (*)(void *, void *)>(fp),
+                       P3 &&param3, P4 &&param4) {
+  return call_with_stack_asm(
+      stack, reinterpret_cast<const void *>(fp),
       reinterpret_cast<void *>(param1), reinterpret_cast<void *>(param2),
       reinterpret_cast<void *>(param3), reinterpret_cast<void *>(param4));
+}
+
+template <typename Function, typename P1, typename P2>
+size_t call_with_stack(void *stack, Function &&fp, P1 &&param1, P2 &&param2) {
+  return call_with_stack_asm(
+      stack, reinterpret_cast<const void *>(fp),
+      reinterpret_cast<void *>(param1), reinterpret_cast<void *>(param2), 0, 0);
 }
 #endif

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -18,7 +18,6 @@
 #include "boot_service.h"
 #include "boot_service_provider.h"
 #include "defer.h"
-#include "kernel/thread.h"
 #include "pe.h"
 
 #include <lib/bio.h>
@@ -40,6 +39,8 @@
 #include "system_table.h"
 #include "text_protocol.h"
 
+namespace {
+
 constexpr auto EFI_SYSTEM_TABLE_SIGNATURE =
     static_cast<u64>(0x5453595320494249ULL);
 
@@ -57,9 +58,9 @@ template <typename T> void fill(T *data, size_t skip, uint8_t begin = 0) {
   }
 }
 
-static constexpr size_t BIT26 = 1 << 26;
-static constexpr size_t BIT11 = 1 << 11;
-static constexpr size_t BIT10 = 1 << 10;
+constexpr size_t BIT26 = 1 << 26;
+constexpr size_t BIT11 = 1 << 11;
+constexpr size_t BIT10 = 1 << 10;
 
 /**
   Pass in a pointer to an ARM MOVT or MOVW immediate instruciton and
@@ -299,7 +300,7 @@ int load_sections_and_execute(bdev_t *dev,
   constexpr size_t kStackSize = 8 * 1024ul * 1024;
   auto stack = reinterpret_cast<char *>(alloc_page(kStackSize, 23));
   memset(stack, 0, kStackSize);
-  printf("Calling kernel with stack [0x%lx, 0x%lx]\n", stack,
+  printf("Calling kernel with stack [%p, %p]\n", stack,
          stack + kStackSize - 1);
   return call_with_stack(stack + kStackSize, entry, image_base, &table);
 }
@@ -373,3 +374,5 @@ int cmd_uefi_load(int argc, const console_cmd_args *argv) {
 STATIC_COMMAND_START
 STATIC_COMMAND("uefi_load", "load UEFI application and run it", &cmd_uefi_load)
 STATIC_COMMAND_END(uefi);
+
+} // namespace


### PR DESCRIPTION
GCC 14 is quite picky about warnings, probably more so than clang.

-Fix a bunch of printf warnings. Pointers should be printed with %p. -Move some stuff into an anonymous namespace.
-Worked around GCC really not liking reinterpret_casting from one function pointer type to another. Fiddled with it a bit and eventually settled on casting the function pointer to const void * and passing it through.