### PR TITLE
[lib][miniheap] fix: modify the assert condition in miniheap

### DIFF
--- a/lib/heap/miniheap/miniheap.c
+++ b/lib/heap/miniheap/miniheap.c
@@ -149,7 +149,7 @@ try_merge:
 
 static struct free_heap_chunk *heap_create_free_chunk(void *ptr, size_t len, bool allow_debug) {
     DEBUG_ASSERT((len % sizeof(void *)) == 0); // size must be aligned on pointer boundary
-    DEBUG_ASSERT(len > sizeof(struct free_heap_chunk));
+    DEBUG_ASSERT(len >= sizeof(struct free_heap_chunk));
 
 #if DEBUG_HEAP
     if (allow_debug)


### PR DESCRIPTION
For LK_DEBUGLEVEL > 1
> alloc_struct_begin_size: 24
> free_heap_chunk_size: 24

size: max(alloc_struct_begin_size, free_heap_chunk_size)

But when freeing the chunk, allocated size is expected to be greater than size of free_heap_chunk struct.
It contradicts its own code.
So add >= instead of > to maintain the integrity between allocation and freeing of memory chunk.