### PR TITLE
atol handles overflow and accepts leading whitespace and '+'

### DIFF
--- a/lib/libc/atoi.c
+++ b/lib/libc/atoi.c
@@ -44,8 +44,13 @@ unsigned int atoui(const char *num) {
 }
 
 long atol(const char *num) {
-    long value = 0;
+    long long value = 0;
     int neg = 0;
+
+    // skip leading whitespace
+    while (isspace(num[0])) {
+        num++;
+    }
 
     if (num[0] == '0' && num[1] == 'x') {
         // hex
@@ -57,7 +62,10 @@ long atol(const char *num) {
         if (num[0] == '-') {
             neg = 1;
             num++;
+        } else if (num[0] == '+') {
+            num++;
         }
+
         while (*num && isdigit(*num))
             value = value * 10 + *num++  - '0';
     }
@@ -65,7 +73,7 @@ long atol(const char *num) {
     if (neg)
         value = -value;
 
-    return value;
+    return (long)value;
 }
 
 unsigned long atoul(const char *num) {


### PR DESCRIPTION
Make `atol()` more robust and compatible with gclib's implementation that

1. accepts leading whitespace
2. accepts leading '+' character
3. handles overflow

Similar adjustments should be made to `atoul` and `atoull`.
I wasn't able to run this project's test suite and since my own (closed source)
project only covers `atol` (see tests in comment), I did not want to
touch anything but this function.