### PR TITLE
Add FVP Base support

### DIFF
--- a/docs/fvp-base/how_to_run.md
+++ b/docs/fvp-base/how_to_run.md
@@ -1,0 +1,80 @@
+# Build and run Fixed Virtual Platform (FVP)
+
+This guide introduces how to build and run little kernel on FVP Base platform
+for Linux users.
+
+Free-of-charge AEM FVPs can be downloaded from Arm Architecture Models on Arm
+Developer without a license. They are available for Linux hosts only.
+ 
+For details read [Introductions FVP
+docs](https://developer.arm.com/documentation/100966/latest/Introduction-to-FVPs/Types-of-FVP)
+
+1- Download FVP Base
+
+[FVP_Base_RevC-2xAEMvA_11.xx_x_Linux64](https://developer.arm.com/Tools%20and%20Software/Fixed%20Virtual%20Platforms/Arm%20Architecture%20FVPs)
+
+2- Clone the repo
+
+```shell
+git clone https://github.com/littlekernel/lk
+cd lk
+```
+
+3- Download appropriate toolchain
+
+```shell
+# Fetches the latest aarch64-elf toolchain for your host.
+scripts/fetch-toolchains.py --prefix aarch64-elf
+``` 
+
+4- Add toolchain to PATH
+
+```shell
+export PATH=$PWD/toolchain/aarch64-elf-14.2.0-Linux-x86_64/bin:$PATH
+```
+
+5- Build kernel
+
+```shell
+make fvp-base-test
+```
+
+6- Clone Trusted Firmware-A (TF-A)
+
+```shell
+cd ..
+git clone https://github.com/ARM-software/arm-trusted-firmware.git 
+cd arm-trsuted-firmware
+```
+
+7- Build Trusted Firmware-A (TF-A)
+
+```shell
+make \
+   BL33=../lk/build-fvp-base-test/lk.bin \
+   DEBUG=1 \
+   FVP_USE_GIC_DRIVER=FVP_GICV2 \
+   LOG_LEVEL=40 \
+   MEASURED_BOOT=0 \
+   CROSS_COMPILE=aarch64-linux-gnu-  \
+   PLAT=fvp all fip
+```
+
+For details of build options you can found at [TF-A build options](https://trustedfirmware-a.readthedocs.io/en/latest/getting_started/build-options.html)
+
+8- Run FVP Base
+
+```shell
+/path/to/FVP_Base_RevC-2xAEMvA_11.xx_xx_Linux64/Base_RevC_AEMvA_pkg/models/Linux64_GCC-9.3/FVP_Base_RevC-2xAEMvA \
+   -C bp.ve_sysregs.exit_on_shutdown=1 \
+   -C cache_state_modelled=0 \
+   -C pctl.startup=0.0.0.0 \
+   -C gicv3.gicv2-only=1 \
+   -C bp.pl011_uart0.out_file=log.txt \
+   -C bp.secure_memory=1 \
+   -C cluster0.NUM_CORES=1 \
+   -C cluster0.has_arm_v8-4=1 \
+   -C cluster1.NUM_CORES=0 \
+   -C bp.secureflashloader.fname=path/to/arm-trusted-firmware/build/fvp/debug/bl1.bin \
+   -C bp.flashloader0.fname=path/to//arm-trusted-firmware/build/fvp/debug/fip.bin
+```

--- a/docs/fvp-base/how_to_run.md
+++ b/docs/fvp-base/how_to_run.md
@@ -56,7 +56,7 @@ make \
    FVP_USE_GIC_DRIVER=FVP_GICV2 \
    LOG_LEVEL=40 \
    MEASURED_BOOT=0 \
-   CROSS_COMPILE=aarch64-linux-gnu-  \
+   CROSS_COMPILE=aarch64-linux-gnu- \
    PLAT=fvp all fip
 ```
 
@@ -76,5 +76,5 @@ For details of build options you can found at [TF-A build options](https://trust
    -C cluster0.has_arm_v8-4=1 \
    -C cluster1.NUM_CORES=0 \
    -C bp.secureflashloader.fname=path/to/arm-trusted-firmware/build/fvp/debug/bl1.bin \
-   -C bp.flashloader0.fname=path/to//arm-trusted-firmware/build/fvp/debug/fip.bin
+   -C bp.flashloader0.fname=path/to/arm-trusted-firmware/build/fvp/debug/fip.bin
 ```

--- a/docs/fvp-base/internal.md
+++ b/docs/fvp-base/internal.md
@@ -1,0 +1,88 @@
+# FVP Base platform overview
+
+### Boot sequence 
+
+FVP Base emulator is typically launched using both a secure flashloader and
+a normal flashloader. The configuration looks like this:
+
+```shell
+-C bp.secureflashloader.fname=path/to/arm-trusted-firmware/build/fvp/debug/bl1.bin \
+-C bp.flashloader0.fname=path/to/lk.bin
+```
+
+We use Arm Trusted Firmware (ATF) as the secure monitor running at S-EL3. It
+initializes the system, sets up the secure world, and pass control to the
+non-secure world.
+
+#### The boot sequence works in the following way:
+
+- BL1 (Secure ROM Bootloader) - Initializes trusted components and loads the
+  next stage (BL2).
+
+- BL2 (Trusted Boot Firmware) - Verifies and loads the next stages: BL31 and
+  BL33.
+
+- BL31 (EL3 Runtime Firmware) - Provides runtime services at EL3, including
+  PSCI (Power State Coordination Interface) and context switching between
+  secure and non-secure worlds.
+
+- BL32 (Secure Payload) - optional secure-world component that runs at S-EL1.
+  It is used to provide Trusted Execution Environment (TEE). If not required,
+  this stage can be skipped, and BL31 will directly pass control to BL33. In our
+  case we do not use BL32.
+
+- BL33 (Non-secure Payload) - The final stage of the boot chain, typically the
+  entry point to the non-secure kernel or bootloader. We use little kernel as
+  BL33.
+
+#### Memory Usage (bytes) [RAM]
+
+| Component |   Start   |   Limit   |  Size   |  Free   | Total  |
+|-----------|-----------|-----------|---------|---------|--------|
+| BL1       | 0x4034000 | 0x4040000 | 0x7000  | 0x5000  | 0xc000 |
+| BL2       | 0x4020000 | 0x4034000 | 0x10000 | 0x4000  | 0x14000|
+| BL2U      | 0x4020000 | 0x4034000 | 0xa000  | 0xa000  | 0x14000|
+| BL31      | 0x4003000 | 0x4040000 | 0x22000 | 0x1b000 | 0x3d000|
+
+#### Memory Usage (bytes) [ROM]
+
+| Component |  Start    |  Limit    |  Size   |   Free    |  Total   |
+|-----------|-----------|-----------|---------|-----------|----------|
+| BL1       | 0x0000000 | 0x4000000 | 0x8bd0  | 0x3ff7430 | 0x4000000|
+
+To check the memory layout, refer to [TF-A Memory Layout Tool
+Documentation](https://trustedfirmware-a.readthedocs.io/en/latest/tools/memory-layout-tool.html)
+
+#### Little kernel and DTB location
+
+On the FVP platform, DTB start address and the BL33 entry point are both
+configured in the platform’s source files:
+
+- **DTB base address**: `0x82000000 (32MB size)`
+- **BL33 entry address**: `0x88000000`
+
+You can find these settings in the `platform_def.h` header file:
+
+- [DTB
+  address](https://github.com/ARM-software/arm-trusted-firmware/blob/v2.12.0/plat/arm/board/fvp/include/platform_def.h#L94-L100)
+- [BL33 entry
+  address](https://github.com/ARM-software/arm-trusted-firmware/blob/v2.12.0/plat/arm/board/fvp/include/platform_def.h#L143)
+
+
+DTS for FVP Base you can find at [fdts](
+https://github.com/ARM-software/arm-trusted-firmware/tree/v2.12.0/fdts)
+
+### Peripheral Address Map
+
+The peripheral address map for the FVP Base platform can be found in the following documentation:  
+[Base Platform memory map](https://developer.arm.com/documentation/100964/latest/Base-Platform/Base-Platform-memory/Base-Platform-memory-map?lang=en)
+
+Currently, little kernel supports:
+
+- **UART0,PL011**  
+- **GICv2**
+
+### Interrupt Assignment
+
+The interrupt assignment for the FVP Base platform can be found in the following documentation:  
+[Base Platform interrupt assignments](https://developer.arm.com/documentation/100964/1128/Base-Platform/Base-Platform-interrupt-assignments?lang=en)

--- a/docs/fvp-base/internal.md
+++ b/docs/fvp-base/internal.md
@@ -7,7 +7,7 @@ a normal flashloader. The configuration looks like this:
 
 ```shell
 -C bp.secureflashloader.fname=path/to/arm-trusted-firmware/build/fvp/debug/bl1.bin \
--C bp.flashloader0.fname=path/to/lk.bin
+-C bp.flashloader0.fname=path/to/fip.bin
 ```
 
 We use Arm Trusted Firmware (ATF) as the secure monitor running at S-EL3. It

--- a/platform/fvp-base/debug.c
+++ b/platform/fvp-base/debug.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Mykola Hohsadze
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ */
+#include <stdarg.h>
+#include <lk/reg.h>
+#include <kernel/thread.h>
+#include <dev/uart.h>
+#include <platform/debug.h>
+#include <platform/fvp-base.h>
+#include <target/debugconfig.h>
+
+/* DEBUG_UART must be defined to 0 */
+#if !defined(DEBUG_UART) || DEBUG_UART != 0
+#error define DEBUG_UART to 0
+#endif
+
+void platform_dputc(char c) {
+    if (c == '\n')
+        uart_putc(DEBUG_UART, '\r');
+    uart_putc(DEBUG_UART, c);
+}
+
+int platform_dgetc(char *c, bool wait) {
+    int ret = uart_getc(DEBUG_UART, wait);
+    if (ret < 0) {
+        return ret;
+    }
+    *c = ret;
+    return 0;
+}

--- a/platform/fvp-base/include/platform/fvp-base.h
+++ b/platform/fvp-base/include/platform/fvp-base.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Mykola Hohsadze
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ */
+#pragma once
+
+/* up to 2 GB of ram */
+#define MEMORY_BASE_PHYS     (0x80000000UL)
+#define MEMORY_APERTURE_SIZE (2ULL * 1024 * 1024 * 1024)
+
+#define DTB_BASE_VIRT (KERNEL_BASE + 0x2000000)
+
+/* map all of 0-2GB into kernel space in one shot */
+#define PERIPHERAL_BASE_PHYS (0)
+#define PERIPHERAL_BASE_SIZE (0x80000000UL) // 2GB
+#define PERIPHERAL_BASE_VIRT (0xffffffff80000000ULL) // -2GB
+
+/* individual peripherals in this mapping */
+#define UART_BASE (PERIPHERAL_BASE_VIRT + 0x001c090000)
+
+/* interrupts */
+#define ARM_GENERIC_TIMER_VIRTUAL_INT (27)
+#define PL011_UART0_INT (32 + 5)
+
+#define MAX_INT 128

--- a/platform/fvp-base/include/platform/gic.h
+++ b/platform/fvp-base/include/platform/gic.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Mykola Hohsadze
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ */
+#pragma once
+
+#include <platform/fvp-base.h>
+
+#define GICBASE(n)  (PERIPHERAL_BASE_VIRT + 0x2c000000UL)
+#define GICD_OFFSET (0x03000000)
+#define GICC_OFFSET (0x0)

--- a/platform/fvp-base/platform.c
+++ b/platform/fvp-base/platform.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Mykola Hohsadze
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ */
+#include <platform/fvp-base.h>
+
+#include <arch.h>
+#include <lk/err.h>
+#include <lk/debug.h>
+#include <lk/trace.h>
+#include <platform.h>
+#include <platform/gic.h>
+#include <platform/interrupts.h>
+#include <dev/interrupt/arm_gic.h>
+#include <dev/timer/arm_generic.h>
+#include <dev/power/psci.h>
+#include <dev/uart/pl011.h>
+#include <lk/init.h>
+#include <lib/fdtwalk.h>
+#include <kernel/vm.h>
+#include <kernel/spinlock.h>
+
+#define LOCAL_TRACE 0
+
+struct mmu_initial_mapping mmu_initial_mappings[] = {
+    {
+        .phys = MEMBASE,
+        .virt = KERNEL_BASE,
+        .size = MEMORY_APERTURE_SIZE,
+        .flags = 0,  // normal memory
+        .name = "memory",
+    },
+    {
+        .phys = PERIPHERAL_BASE_PHYS,
+        .virt = PERIPHERAL_BASE_VIRT,
+        .size = PERIPHERAL_BASE_SIZE,
+        .flags = MMU_INITIAL_MAPPING_FLAG_DEVICE,
+        .name = "peripherals",
+    },
+    { 0 }
+};
+
+const void *fdt = (void *)DTB_BASE_VIRT;
+
+const void *get_fdt(void) {
+    return fdt;
+}
+
+void platform_early_init(void) {
+    const struct pl011_config uart_config = {
+        .base = UART_BASE,
+        .irq = PL011_UART0_INT,
+        .flag = PL011_FLAG_DEBUG_UART,
+    };
+
+    pl011_init_early(0, &uart_config);
+
+    arm_gic_init();
+
+    arm_generic_timer_init(ARM_GENERIC_TIMER_VIRTUAL_INT, 0);
+
+    if (LOCAL_TRACE) {
+        LTRACEF("dumping FDT at %p\n", fdt);
+        fdt_walk_dump(fdt);
+    }
+
+    // detect physical memory layout from the device tree
+    fdtwalk_setup_memory(fdt, MEMORY_BASE_PHYS, MEMORY_BASE_PHYS, MEMSIZE);
+}
+
+void platform_init(void) {
+    pl011_init(0);
+}
+
+void platform_halt(platform_halt_action suggested_action, platform_halt_reason reason) {
+    // Use the default halt implementation using psci as the reset and shutdown implementation.
+    platform_halt_default(suggested_action, reason, &psci_system_reset, &psci_system_off);
+}

--- a/platform/fvp-base/rules.mk
+++ b/platform/fvp-base/rules.mk
@@ -1,0 +1,35 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+MODULE := $(LOCAL_DIR)
+
+LK_HEAP_IMPLEMENTATION ?= dlmalloc
+
+ARCH	:= arm64
+ARM_CPU := cortex-a53
+CPU	:= generic
+WITH_SMP := 1
+
+MODULE_SRCS += $(LOCAL_DIR)/debug.c
+MODULE_SRCS += $(LOCAL_DIR)/platform.c
+
+MEMBASE := 0x80000000
+MEMSIZE ?= 0x80000000
+KERNEL_LOAD_OFFSET := 0x8000000
+
+MODULE_DEPS += \
+    dev/power/psci \
+    dev/interrupt/arm_gic \
+    dev/timer/arm_generic \
+    dev/uart/pl011 \
+    lib/fdtwalk \
+
+GLOBAL_DEFINES += \
+    MEMBASE=$(MEMBASE) \
+    MEMSIZE=$(MEMSIZE) \
+    MMU_WITH_TRAMPOLINE=1 \
+    TIMER_ARM_GENERIC_SELECTED=CNTV
+
+LINKER_SCRIPT += \
+    $(BUILDDIR)/system-onesegment.ld
+
+include make/module.mk

--- a/project/fvp-base-test.mk
+++ b/project/fvp-base-test.mk
@@ -1,0 +1,7 @@
+# main project for fvp-base
+MODULES += \
+  app/shell \
+
+include project/virtual/test.mk
+include project/target/fvp-base.mk
+

--- a/project/target/fvp-base.mk
+++ b/project/target/fvp-base.mk
@@ -1,0 +1,4 @@
+# main project for fvp-base-aarch64
+ARCH := arm64
+ARM_CPU := cortex-a53
+TARGET := fvp-base

--- a/target/fvp-base/include/target/debugconfig.h
+++ b/target/fvp-base/include/target/debugconfig.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Mykola Hohsadze
+ *
+ * Use of this source code is governed by a MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT
+ */
+#pragma once
+
+#define DEBUG_UART 0

--- a/target/fvp-base/rules.mk
+++ b/target/fvp-base/rules.mk
@@ -1,0 +1,6 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+GLOBAL_INCLUDES += \
+    $(LOCAL_DIR)/include
+
+PLATFORM := fvp-base


### PR DESCRIPTION
Add initial support of FVP Base platform, supported peripherals:

* Arm Virtual Timer
* GICv2
* UART

uart0 log: [log.txt](https://github.com/user-attachments/files/20028953/log.txt)