### PR TITLE
[lib][uefi] Make load_pe_file extern linkage

### DIFF
--- a/.github/workflows/github-ci-clang.yml
+++ b/.github/workflows/github-ci-clang.yml
@@ -72,6 +72,7 @@ jobs:
       if: ${{ matrix.project == 'qemu-virt-arm64-test' }}
       shell: bash
       run: |
+        env -i DEBIAN_FRONTEND=noninteractive sudo apt-get update
         env -i DEBIAN_FRONTEND=noninteractive sudo apt-get install -y qemu-system-arm
     - name: unittest
       if: ${{ matrix.project == 'qemu-virt-arm64-test' }}

--- a/scripts/unittest.py
+++ b/scripts/unittest.py
@@ -66,7 +66,7 @@ def main():
     try:
         os.set_blocking(p.stdout.fileno(), False)
         condition_met, output = wait_for_output(
-            p.stdout, lambda l: "starting app shell" in l, 0.5)
+            p.stdout, lambda l: "starting app shell" in l, 1)
         assert condition_met, "Did not see 'starting app shell', stdout: {}".format(
             "".join(output))
         p.stdin.write("uefi_load virtio0\n")


### PR DESCRIPTION
This function was previously put in anon namespace, making it unavailable for other source files to consume. Since we made this function an API for consumption, move outside anon namespace so that linkers can find it.