### PR TITLE
[lib][libc] Make errno thread safe using TLS APIs

### DIFF
--- a/kernel/include/kernel/thread.h
+++ b/kernel/include/kernel/thread.h
@@ -57,6 +57,7 @@ enum thread_tls_list {
 #ifdef WITH_LIB_LKUSER
     TLS_ENTRY_LKUSER,
 #endif
+    TLS_ENTRY_ERRNO,
     MAX_TLS_ENTRY
 };
 

--- a/lib/libc/errno.c
+++ b/lib/libc/errno.c
@@ -7,12 +7,9 @@
  */
 
 #include <errno.h>
-
-/* completely un-threadsafe implementation of errno */
-/* TODO: pull from kernel TLS or some other thread local storage */
-static int _errno;
+#include <kernel/thread.h>
 
 int *__geterrno(void) {
-    return &_errno;
+    return (int*)tls_get(TLS_ENTRY_ERRNO);
 }
 


### PR DESCRIPTION
Before this change, errno was "completely un-threadsafe" as the comment states.

This changes errno to be threadsafe by making errno a thread local variable.