### PR TITLE
Reset errno values where read

### DIFF
--- a/tools/bootimage.c
+++ b/tools/bootimage.c
@@ -96,6 +96,7 @@ static int writex(int fd, void *data, size_t len) {
     int r;
     char *x = data;
     while (len > 0) {
+        errno = NO_ERROR;
         r = write(fd, x, len);
         if (r < 0) {
             if (errno == EINTR) {
@@ -162,6 +163,7 @@ static void *load_file(const char *fn, size_t *len) {
         *len = sz;
     }
     while (sz > 0) {
+        errno = NO_ERROR;
         r = read(fd, x, sz);
         if (r < 0) {
             if (errno == EINTR) {

--- a/tools/liblkboot.c
+++ b/tools/liblkboot.c
@@ -21,6 +21,7 @@ static int readx(int s, void *_data, int len) {
     char *data = _data;
     int r;
     while (len > 0) {
+        errno = NO_ERROR;
         r = read(s, data, len);
         if (r == 0) {
             fprintf(stderr, "error: eof during socket read\n");


### PR DESCRIPTION
According to `man 3 errno`:

```
The value of errno is never set to zero by any system
call or library function.
```

So we must set it to 0 ourselves before each `read` and `write` call to ensure we don't get stuck in an error loop.