### PR TITLE
[lib][uefi] Implement EFI_TIMESTAMP_PROTOCOL

### DIFF
--- a/lib/uefi/boot_service_provider.cpp
+++ b/lib/uefi/boot_service_provider.cpp
@@ -239,10 +239,9 @@ EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, void **intf,
            __FUNCTION__, handle, agent_handle, controller_handle, attr);
     return SUCCESS;
   } else if (guid_eq(protocol, EFI_DEVICE_PATH_PROTOCOL_GUID)) {
-    printf(
-        "%s(EFI_DEVICE_PATH_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-        "controller_handle=%p, attr=0x%x)\n",
-        __FUNCTION__, handle, agent_handle, controller_handle, attr);
+    printf("%s(EFI_DEVICE_PATH_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
+           "controller_handle=%p, attr=0x%x)\n",
+           __FUNCTION__, handle, agent_handle, controller_handle, attr);
     return UNSUPPORTED;
   } else if (guid_eq(protocol, EFI_BLOCK_IO_PROTOCOL_GUID)) {
     printf("%s(EFI_BLOCK_IO_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
@@ -300,6 +299,19 @@ EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, void **intf,
     image_loading->revision = GBL_EFI_IMAGE_LOADING_PROTOCOL_REVISION;
     *intf = reinterpret_cast<void *>(image_loading);
     return SUCCESS;
+  } else if (guid_eq(protocol, EFI_TIMESTAMP_PROTOCOL_GUID)) {
+    printf("%s(EFI_TIMESTAMP_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
+           "controller_handle=%p, attr=0x%x)\n",
+           __FUNCTION__, handle, agent_handle, controller_handle, attr);
+    EfiTimestampProtocol *ts = reinterpret_cast<EfiTimestampProtocol *>(
+        uefi_malloc(sizeof(EfiTimestampProtocol)));
+    if (ts == nullptr) {
+      return OUT_OF_RESOURCES;
+    }
+    ts->get_timestamp = get_timestamp;
+    ts->get_properties = get_timestamp_properties;
+    *intf = reinterpret_cast<void *>(ts);
+    return SUCCESS;
   }
   printf("%s is unsupported 0x%x 0x%x 0x%x 0x%llx\n", __FUNCTION__,
          protocol->data1, protocol->data2, protocol->data3,
@@ -315,10 +327,9 @@ EfiStatus close_protocol(EfiHandle handle, const EfiGuid *protocol,
            __FUNCTION__, handle, agent_handle, controller_handle);
     return SUCCESS;
   } else if (guid_eq(protocol, EFI_DEVICE_PATH_PROTOCOL_GUID)) {
-    printf(
-        "%s(EFI_DEVICE_PATH_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-        "controller_handle=%p)\n",
-        __FUNCTION__, handle, agent_handle, controller_handle);
+    printf("%s(EFI_DEVICE_PATH_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
+           "controller_handle=%p)\n",
+           __FUNCTION__, handle, agent_handle, controller_handle);
     return SUCCESS;
   } else if (guid_eq(protocol, EFI_BLOCK_IO_PROTOCOL_GUID)) {
     printf("%s(EFI_BLOCK_IO_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
@@ -350,9 +361,8 @@ EfiStatus locate_handle_buffer(EfiLocateHandleSearchType search_type,
            __FUNCTION__, search_type, search_key);
     return NOT_FOUND;
   } else if (guid_eq(protocol, EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID)) {
-    printf(
-        "%s(0x%x, EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID, search_key=%p)\n",
-        __FUNCTION__, search_type, search_key);
+    printf("%s(0x%x, EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID, search_key=%p)\n",
+           __FUNCTION__, search_type, search_key);
     if (num_handles != nullptr) {
       *num_handles = 1;
     }
@@ -362,6 +372,16 @@ EfiStatus locate_handle_buffer(EfiLocateHandleSearchType search_type,
     return SUCCESS;
   } else if (guid_eq(protocol, EFI_DT_FIXUP_PROTOCOL_GUID)) {
     printf("%s(0x%x, EFI_DT_FIXUP_PROTOCOL_GUID, search_key=%p)\n",
+           __FUNCTION__, search_type, search_key);
+    if (num_handles != nullptr) {
+      *num_handles = 1;
+    }
+    if (buf != nullptr) {
+      *buf = reinterpret_cast<EfiHandle *>(uefi_malloc(sizeof(buf)));
+    }
+    return SUCCESS;
+  } else if (guid_eq(protocol, EFI_TIMESTAMP_PROTOCOL_GUID)) {
+    printf("%s(0x%x, EFI_TIMESTAMP_PROTOCOL_GUID, search_key=%p)\n",
            __FUNCTION__, search_type, search_key);
     if (num_handles != nullptr) {
       *num_handles = 1;

--- a/lib/uefi/boot_service_provider.h
+++ b/lib/uefi/boot_service_provider.h
@@ -92,6 +92,12 @@ static constexpr auto EFI_DT_FIXUP_PROTOCOL_GUID =
             0x46da,
             {0xf4, 0xdc, 0xbb, 0xd5, 0x87, 0x0c, 0x73, 0x00}};
 
+static constexpr auto EFI_TIMESTAMP_PROTOCOL_GUID =
+    EfiGuid{0xafbfde41,
+            0x2e6e,
+            0x4262,
+            {0xba, 0x65, 0x62, 0xb9, 0x23, 0x6e, 0x54, 0x95}};
+
 using EFI_IMAGE_UNLOAD = EfiStatus (*)(EfiHandle);
 
 //******************************************************

--- a/lib/uefi/include/uefi/protocols/efi_timestamp_protocol.h
+++ b/lib/uefi/include/uefi/protocols/efi_timestamp_protocol.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Reference:
+// https://uefi.org/specs/UEFI/2.10/39_Micellaneous_Protocols.html#efi-timestamp-protocol
+
+#pragma once
+
+#include <uefi/types.h>
+
+typedef struct EfiTimestampProperties {
+  uint64_t frequency;
+  uint64_t end_value;
+} EfiTimestampProperties;
+
+typedef struct EfiTimestampProtocol {
+  uint64_t (*get_timestamp)();
+  EfiStatus (*get_properties)(EfiTimestampProperties *properties);
+} EfiTimestampProtocol;

--- a/lib/uefi/uefi_platform.cpp
+++ b/lib/uefi/uefi_platform.cpp
@@ -17,6 +17,7 @@
 
 #include "uefi_platform.h"
 
+#include <arch/arm64.h>
 #include <libfdt.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -93,5 +94,18 @@ __WEAK EfiStatus exit_boot_services(EfiHandle image_handle, size_t map_key) {
 
 __WEAK EfiStatus platform_setup_system_table(EfiSystemTable *table) {
   printf("%s is called\n", __FUNCTION__);
+  return SUCCESS;
+}
+
+__WEAK uint64_t get_timestamp() {
+  return ARM64_READ_SYSREG(cntpct_el0);
+}
+
+__WEAK EfiStatus get_timestamp_properties(EfiTimestampProperties *properties) {
+  if (properties == nullptr) {
+    return INVALID_PARAMETER;
+  }
+  properties->frequency = ARM64_READ_SYSREG(cntfrq_el0) & 0xFFFFFFFF;
+  properties->end_value = UINT64_MAX;
   return SUCCESS;
 }

--- a/lib/uefi/uefi_platform.h
+++ b/lib/uefi/uefi_platform.h
@@ -18,6 +18,7 @@
 #ifndef __GBL_OS_CONFIGURATION_
 #define __GBL_OS_CONFIGURATION_
 
+#include <uefi/protocols/efi_timestamp_protocol.h>
 #include <uefi/protocols/gbl_efi_os_configuration_protocol.h>
 #include <uefi/system_table.h>
 #include <uefi/types.h>
@@ -39,5 +40,9 @@ EfiStatus select_device_trees(struct GblEfiOsConfigurationProtocol *self,
 EfiStatus exit_boot_services(EfiHandle image_handle, size_t map_key);
 
 EfiStatus platform_setup_system_table(EfiSystemTable *table);
+
+uint64_t get_timestamp();
+
+EfiStatus get_timestamp_properties(EfiTimestampProperties *properties);
 
 #endif


### PR DESCRIPTION
Reads the ARM64-specific counter registers.
This only works on ARM64 platform obviously, which is the only platform we support for UEFI at the moment.

