### PR TITLE
Add UEFI Debug Support Protocol

### DIFF
--- a/lib/uefi/boot_service_provider.cpp
+++ b/lib/uefi/boot_service_provider.cpp
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <platform.h>
 #include <sys/types.h>
 #include <uefi/boot_service.h>
 #include <uefi/protocols/block_io_protocol.h>
@@ -397,6 +398,17 @@ EfiStatus locate_handle_buffer(EfiLocateHandleSearchType search_type,
   return UNSUPPORTED;
 }
 
+EfiStatus stall(size_t microseconds) {
+  uint64_t end_microseconds;
+
+  end_microseconds = current_time_hires() + microseconds;
+  while (current_time_hires() < end_microseconds) {
+    thread_yield();
+  }
+
+  return SUCCESS;
+}
+
 } // namespace
 
 void setup_boot_service_table(EfiBootService *service) {
@@ -428,4 +440,5 @@ void setup_boot_service_table(EfiBootService *service) {
   service->check_event = switch_stack_wrapper<EfiEvent, check_event>();
   service->create_event = create_event;
   service->close_event = close_event;
+  service->stall = stall;
 }

--- a/lib/uefi/configuration_table.cpp
+++ b/lib/uefi/configuration_table.cpp
@@ -23,6 +23,7 @@
 
 #include "memory_protocols.h"
 #include "platform.h"
+#include "debug_support.h"
 
 void setup_configuration_table(EfiSystemTable *table) {
   auto &rng = table->configuration_table[table->number_of_table_entries++];
@@ -40,4 +41,8 @@ void setup_configuration_table(EfiSystemTable *table) {
     dtb.vendor_table = alloc_page(fdt_size);
     memcpy(dtb.vendor_table, fdt, fdt_size);
   }
+
+  auto &debug_image_info_table = table->configuration_table[table->number_of_table_entries++];
+  debug_image_info_table.vendor_guid = EFI_DEBUG_IMAGE_INFO_TABLE_GUID;
+  debug_image_info_table.vendor_table = &efi_m_debug_info_table_header;
 }

--- a/lib/uefi/debug_support.cpp
+++ b/lib/uefi/debug_support.cpp
@@ -29,6 +29,12 @@ namespace {
   struct EfiSystemTablePointer *efi_systab_pointer = nullptr;
 }
 
+struct EfiDebugImageInfoTableHeader efi_m_debug_info_table_header = {
+  0,
+  0,
+  nullptr
+};
+
 EfiStatus efi_initialize_system_table_pointer(struct EfiSystemTable *system_table) {
   uint32_t crc = 0;
   constexpr auto EFI_SYSTEM_TABLE_SIGNATURE =

--- a/lib/uefi/debug_support.cpp
+++ b/lib/uefi/debug_support.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "debug_support.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <lib/cksum.h>
+#include <uefi/boot_service.h>
+#include <uefi/types.h>
+
+#include "memory_protocols.h"
+
+namespace {
+  struct EfiSystemTablePointer *efi_systab_pointer = nullptr;
+}
+
+EfiStatus efi_initialize_system_table_pointer(struct EfiSystemTable *system_table) {
+  uint32_t crc = 0;
+  constexpr auto EFI_SYSTEM_TABLE_SIGNATURE =
+    static_cast<u64>(0x5453595320494249ULL);
+
+  /* Allocate efi_system_table_pointer structure with 4MB alignment. */
+  efi_systab_pointer = reinterpret_cast<EfiSystemTablePointer *>(alloc_page(sizeof(struct EfiSystemTablePointer), 22));
+
+  if (!efi_systab_pointer) {
+    printf("Installing EFI system table pointer failed\n");
+    return OUT_OF_RESOURCES;
+  }
+
+  memset(efi_systab_pointer, 0, sizeof(struct EfiSystemTablePointer));
+
+  efi_systab_pointer->signature = EFI_SYSTEM_TABLE_SIGNATURE;
+  efi_systab_pointer->system_table_base = system_table;
+
+  crc = crc32(crc,
+	      (uint8_t *)efi_systab_pointer,
+	      sizeof(struct EfiSystemTablePointer));
+
+  efi_systab_pointer->crc32 = crc;
+
+  return SUCCESS;
+}

--- a/lib/uefi/debug_support.cpp
+++ b/lib/uefi/debug_support.cpp
@@ -23,7 +23,18 @@
 #include <uefi/boot_service.h>
 #include <uefi/types.h>
 
+#include "boot_service_provider.h"
 #include "memory_protocols.h"
+
+struct EFI_DEVICE_PATH_FILE_PATH_PROTOCOL {
+  struct EFI_DEVICE_PATH_PROTOCOL dp;
+  uint16_t str[];
+};
+
+static constexpr size_t EFI_DEVICE_PATH_TYPE_END = 0x7f;
+static constexpr size_t EFI_DEVICE_PATH_SUB_TYPE_END = 0xff;
+static constexpr size_t EFI_DEVICE_PATH_TYPE_MEDIA_DEVICE = 0x4;
+static constexpr size_t EFI_DEVICE_PATH_SUB_TYPE_FILE_PATH = 0x4;
 
 namespace {
   struct EfiSystemTablePointer *efi_systab_pointer = nullptr;
@@ -60,4 +71,192 @@ EfiStatus efi_initialize_system_table_pointer(struct EfiSystemTable *system_tabl
   efi_systab_pointer->crc32 = crc;
 
   return SUCCESS;
+}
+
+static uint32_t efi_m_max_table_entries;
+
+static constexpr size_t EFI_DEBUG_TABLE_ENTRY_SIZE = (sizeof(union EfiDebugImageInfo));
+
+EfiStatus efi_core_new_debug_image_info_entry(uint32_t image_info_type,
+					      struct EFI_LOADED_IMAGE_PROTOCOL *loaded_image,
+					      EfiHandle image_handle) {
+  /* Set the flag indicating that we're in the process of updating
+   * the table.
+   */
+  efi_m_debug_info_table_header.update_status |=
+    EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS;
+
+  union EfiDebugImageInfo *table;
+  table = efi_m_debug_info_table_header.efi_debug_image_info_table;
+
+  if (efi_m_debug_info_table_header.table_size >= efi_m_max_table_entries) {
+    /* table is full, re-allocate the buffer increasing the size
+     * by 4 KiB.
+     */
+    uint32_t table_size = efi_m_max_table_entries * EFI_DEBUG_TABLE_ENTRY_SIZE;
+    union EfiDebugImageInfo *new_table;
+    allocate_pool(BOOT_SERVICES_DATA,
+		  table_size + PAGE_SIZE,
+		  reinterpret_cast<void **>(&new_table));
+
+    if (!new_table) {
+      efi_m_debug_info_table_header.update_status &=
+	~EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS;
+      return OUT_OF_RESOURCES;
+    }
+
+    memset(new_table, 0, table_size + PAGE_SIZE);
+
+    /* Copy the old table into the new one. */
+    memcpy(new_table, table, table_size);
+    /* Free the old table. */
+    free_pool(table);
+    /* Update the table header. */
+    table = new_table;
+    efi_m_debug_info_table_header.efi_debug_image_info_table =
+      new_table;
+
+    /* Enlarge the max table entries and set the first empty
+     * entry index to be the original max table entries.
+     */
+    efi_m_max_table_entries +=
+      PAGE_SIZE / EFI_DEBUG_TABLE_ENTRY_SIZE;
+  }
+
+  /* We always put the next entry at the end of the currently consumed
+   * table (i.e. first free entry)
+   */
+  uint32_t index = efi_m_debug_info_table_header.table_size;
+
+  /* Allocate data for new entry. */
+  allocate_pool(BOOT_SERVICES_DATA,
+		      sizeof(union EfiDebugImageInfo),
+		      reinterpret_cast<void **>(&table[index].normal_image));
+  if (table[index].normal_image) {
+    /* Update the entry. */
+    table[index].normal_image->image_info_type = image_info_type;
+    table[index].normal_image->loaded_image_protocol_instance =
+      loaded_image;
+    table[index].normal_image->image_handle = image_handle;
+
+    /* Increase the number of EFI_DEBUG_IMAGE_INFO elements and
+     * set the efi_m_debug_info_table_header in modified status.
+     */
+    efi_m_debug_info_table_header.table_size++;
+    efi_m_debug_info_table_header.update_status |=
+      EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED;
+  } else {
+    return OUT_OF_RESOURCES;
+  }
+
+  efi_m_debug_info_table_header.update_status &=
+    ~EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS;
+
+  return SUCCESS;
+}
+
+void efi_core_remove_debug_image_info_entry(EfiHandle image_handle)
+{
+  efi_m_debug_info_table_header.update_status |=
+    EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS;
+
+  union EfiDebugImageInfo *table;
+  table = efi_m_debug_info_table_header.efi_debug_image_info_table;
+
+  for (uint32_t index = 0; index < efi_m_max_table_entries; index++) {
+    if (table[index].normal_image &&
+	table[index].normal_image->image_handle == image_handle) {
+      /* Found a match. Free up the table entry.
+       * Move the tail of the table one slot to the front.
+       */
+      free_pool(table[index].normal_image);
+
+      memmove(&table[index],
+	      &table[index + 1],
+	      (efi_m_debug_info_table_header.table_size -
+	       index - 1) * EFI_DEBUG_TABLE_ENTRY_SIZE);
+
+      /* Decrease the number of EFI_DEBUG_IMAGE_INFO
+       * elements and set the efi_m_debug_info_table_header
+       * in modified status.
+       */
+      efi_m_debug_info_table_header.table_size--;
+      table[efi_m_debug_info_table_header.table_size].normal_image =
+	nullptr;
+      efi_m_debug_info_table_header.update_status |=
+	EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED;
+      break;
+    }
+  }
+
+  efi_m_debug_info_table_header.update_status &=
+    ~EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS;
+}
+
+EfiStatus setup_debug_support(EfiSystemTable &table,
+			      char *image_base,
+			      size_t virtual_size,
+			      bdev_t *dev) {
+  struct EFI_LOADED_IMAGE_PROTOCOL *efiLoadedImageProtocol = nullptr;
+
+  allocate_pool(BOOT_SERVICES_DATA,
+		sizeof(struct EFI_LOADED_IMAGE_PROTOCOL),
+		reinterpret_cast<void **>(&efiLoadedImageProtocol));
+  memset(efiLoadedImageProtocol, 0, sizeof(struct EFI_LOADED_IMAGE_PROTOCOL));
+
+  efiLoadedImageProtocol->Revision = EFI_LOADED_IMAGE_PROTOCOL_REVISION;
+  efiLoadedImageProtocol->SystemTable = &table;
+  efiLoadedImageProtocol->ImageBase = reinterpret_cast<void *>(image_base);
+  efiLoadedImageProtocol->ImageSize = virtual_size;
+  char *device_buf = nullptr;
+  size_t fpsize = sizeof(struct EFI_DEVICE_PATH_PROTOCOL) + 2 * (strlen(dev->name) + 2);
+  allocate_pool(BOOT_SERVICES_DATA,
+		fpsize + sizeof(struct EFI_DEVICE_PATH_PROTOCOL),
+		reinterpret_cast<void **>(&device_buf));
+  memset(device_buf, 0, fpsize + sizeof(struct EFI_DEVICE_PATH_PROTOCOL));
+  struct EFI_DEVICE_PATH_FILE_PATH_PROTOCOL *fp = reinterpret_cast<struct EFI_DEVICE_PATH_FILE_PATH_PROTOCOL *>(device_buf);
+  struct EFI_DEVICE_PATH_PROTOCOL *dp_end = reinterpret_cast<struct EFI_DEVICE_PATH_PROTOCOL *>(device_buf + fpsize);
+  fp->dp.Type = EFI_DEVICE_PATH_TYPE_MEDIA_DEVICE;
+  fp->dp.SubType = EFI_DEVICE_PATH_SUB_TYPE_FILE_PATH;
+  fp->dp.Length[0] = fpsize % 256;
+  fp->dp.Length[1] = fpsize / 256;
+  fp->str[0] = '\\';
+  for (size_t i = 0; i < strlen(dev->name); i++) {
+    fp->str[i+1] = dev->name[i];
+  }
+  dp_end->Type = EFI_DEVICE_PATH_TYPE_END;
+  dp_end->SubType = EFI_DEVICE_PATH_SUB_TYPE_END;
+  dp_end->Length[0] = sizeof(struct EFI_DEVICE_PATH_PROTOCOL) % 256;
+  dp_end->Length[1] = sizeof(struct EFI_DEVICE_PATH_PROTOCOL) / 256;
+  efiLoadedImageProtocol->FilePath = reinterpret_cast<struct EFI_DEVICE_PATH_PROTOCOL *>(device_buf);
+  return efi_core_new_debug_image_info_entry(EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL,
+					     efiLoadedImageProtocol,
+					     image_base);
+}
+
+void teardown_debug_support(char *image_base) {
+  char *device_buf = nullptr;
+  struct EFI_LOADED_IMAGE_PROTOCOL *efiLoadedImageProtocol = nullptr;
+
+  union EfiDebugImageInfo *table;
+  table = efi_m_debug_info_table_header.efi_debug_image_info_table;
+
+  for (uint32_t index = 0; index < efi_m_debug_info_table_header.table_size; index++) {
+    if (table[index].normal_image &&
+	table[index].normal_image->image_handle == image_base) {
+      /* Found a match. Get device_buf and efiLoadedImageProtocol.
+       */
+      efiLoadedImageProtocol = table[index].normal_image->loaded_image_protocol_instance;
+      device_buf = reinterpret_cast<char *>(efiLoadedImageProtocol->FilePath);
+      break;
+    }
+  }
+
+  efi_core_remove_debug_image_info_entry(image_base);
+  if (device_buf) {
+    free_pool(device_buf);
+  }
+  if (efiLoadedImageProtocol) {
+    free_pool(efiLoadedImageProtocol);
+  }
 }

--- a/lib/uefi/debug_support.h
+++ b/lib/uefi/debug_support.h
@@ -20,6 +20,16 @@
 
 #include <uefi/system_table.h>
 #include <uefi/types.h>
+#include <uefi/protocols/loaded_image_protocol.h>
+
+static constexpr auto EFI_DEBUG_IMAGE_INFO_TABLE_GUID =
+    EfiGuid{0x49152e77,
+            0x1ada,
+            0x4764,
+            {0xb7, 0xa2, 0x7a, 0xfe, 0xfe, 0xd9, 0x5e, 0x8b}};
+
+static constexpr size_t EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS = 0x01;
+static constexpr size_t EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED = 0x02;
 
 struct EfiSystemTablePointer {
   uint64_t signature;
@@ -27,6 +37,25 @@ struct EfiSystemTablePointer {
   uint32_t crc32;
 };
 
+struct EfiDebugImageInfoNormal {
+  uint32_t image_info_type;
+  EfiLoadedImageProtocol *loaded_image_protocol_instance;
+  EfiHandle image_handle;
+};
+
+union EfiDebugImageInfo {
+  uint32_t *image_info_type;
+  struct EfiDebugImageInfoNormal *normal_image;
+};
+
+struct EfiDebugImageInfoTableHeader {
+  volatile uint32_t update_status;
+  uint32_t table_size;
+  union EfiDebugImageInfo *efi_debug_image_info_table;
+};
+
 EfiStatus efi_initialize_system_table_pointer(struct EfiSystemTable *system_table);
+
+extern struct EfiDebugImageInfoTableHeader efi_m_debug_info_table_header;
 
 #endif

--- a/lib/uefi/debug_support.h
+++ b/lib/uefi/debug_support.h
@@ -18,9 +18,9 @@
 #ifndef __DEBUG_SUPPORT_
 #define __DEBUG_SUPPORT_
 
+#include <lib/bio.h>
 #include <uefi/system_table.h>
 #include <uefi/types.h>
-#include <uefi/protocols/loaded_image_protocol.h>
 
 static constexpr auto EFI_DEBUG_IMAGE_INFO_TABLE_GUID =
     EfiGuid{0x49152e77,
@@ -31,6 +31,8 @@ static constexpr auto EFI_DEBUG_IMAGE_INFO_TABLE_GUID =
 static constexpr size_t EFI_DEBUG_IMAGE_INFO_UPDATE_IN_PROGRESS = 0x01;
 static constexpr size_t EFI_DEBUG_IMAGE_INFO_TABLE_MODIFIED = 0x02;
 
+static constexpr size_t EFI_DEBUG_IMAGE_INFO_TYPE_NORMAL = 0x01;
+
 struct EfiSystemTablePointer {
   uint64_t signature;
   EfiSystemTable *system_table_base;
@@ -39,7 +41,7 @@ struct EfiSystemTablePointer {
 
 struct EfiDebugImageInfoNormal {
   uint32_t image_info_type;
-  EfiLoadedImageProtocol *loaded_image_protocol_instance;
+  struct EFI_LOADED_IMAGE_PROTOCOL *loaded_image_protocol_instance;
   EfiHandle image_handle;
 };
 
@@ -55,6 +57,16 @@ struct EfiDebugImageInfoTableHeader {
 };
 
 EfiStatus efi_initialize_system_table_pointer(struct EfiSystemTable *system_table);
+EfiStatus efi_core_new_debug_image_info_entry(uint32_t image_info_type,
+                                              struct EFI_LOADED_IMAGE_PROTOCOL *loaded_image,
+                                              EfiHandle image_handle);
+void efi_core_remove_debug_image_info_entry(EfiHandle image_handle);
+EfiStatus setup_debug_support(EfiSystemTable &table,
+			      char *image_base,
+			      size_t virtual_size,
+			      bdev_t *dev);
+
+void teardown_debug_support(char *image_base);
 
 extern struct EfiDebugImageInfoTableHeader efi_m_debug_info_table_header;
 

--- a/lib/uefi/debug_support.h
+++ b/lib/uefi/debug_support.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef __DEBUG_SUPPORT_
+#define __DEBUG_SUPPORT_
+
+#include <uefi/system_table.h>
+#include <uefi/types.h>
+
+struct EfiSystemTablePointer {
+  uint64_t signature;
+  EfiSystemTable *system_table_base;
+  uint32_t crc32;
+};
+
+EfiStatus efi_initialize_system_table_pointer(struct EfiSystemTable *system_table);
+
+#endif

--- a/lib/uefi/rules.mk
+++ b/lib/uefi/rules.mk
@@ -20,6 +20,7 @@ MODULE_SRCS += \
 	$(LOCAL_DIR)/configuration_table.cpp \
 	$(LOCAL_DIR)/events.cpp \
 	$(LOCAL_DIR)/io_stack.cpp \
+	$(LOCAL_DIR)/debug_support.cpp \
 
 
 include make/module.mk

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -143,6 +143,7 @@ int load_sections_and_execute(bdev_t *dev,
     printf("efi_initialize_system_table_pointer failed: %lu\n", status);
     return -static_cast<int>(status);
   }
+  setup_debug_support(table, image_base, virtual_size, dev);
 
   constexpr size_t kStackSize = 1 * 1024ul * 1024;
   auto stack = reinterpret_cast<char *>(alloc_page(kStackSize, 23));
@@ -152,8 +153,12 @@ int load_sections_and_execute(bdev_t *dev,
     stack = nullptr;
   };
   printf("Calling kernel with stack [%p, %p]\n", stack, stack + kStackSize - 1);
-  return static_cast<int>(
+  int ret = static_cast<int>(
       call_with_stack(stack + kStackSize, entry, image_base, &table));
+
+  teardown_debug_support(image_base);
+
+  return ret;
 }
 
 int cmd_uefi_load(int argc, const console_cmd_args *argv) {

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -63,6 +63,8 @@ void fill(T *data, size_t skip, uint8_t begin = 0) {
   }
 }
 
+static char16_t firmwareVendor[] = u"Little Kernel";
+
 int load_sections_and_execute(bdev_t *dev,
                               const IMAGE_NT_HEADERS64 *pe_header) {
   const auto file_header = &pe_header->FileHeader;
@@ -118,6 +120,7 @@ int load_sections_and_execute(bdev_t *dev,
   fill(&boot_service, 0);
   setup_runtime_service_table(&runtime_service);
   setup_boot_service_table(&boot_service);
+  table.firmware_vendor = firmwareVendor;
   table.runtime_service = &runtime_service;
   table.boot_services = &boot_service;
   table.header.signature = EFI_SYSTEM_TABLE_SIGNATURE;

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -42,6 +42,7 @@
 #include "switch_stack.h"
 #include "text_protocol.h"
 #include "uefi_platform.h"
+#include "debug_support.h"
 
 namespace {
 
@@ -135,6 +136,11 @@ int load_sections_and_execute(bdev_t *dev,
   auto status = platform_setup_system_table(&table);
   if (status != SUCCESS) {
     printf("platform_setup_system_table failed: %lu\n", status);
+    return -static_cast<int>(status);
+  }
+  status = efi_initialize_system_table_pointer(&table);
+  if (status != SUCCESS) {
+    printf("efi_initialize_system_table_pointer failed: %lu\n", status);
     return -static_cast<int>(status);
   }
 


### PR DESCRIPTION
I implemented the UEFI Specification version 2.10, specifically focusing on
the functionality described in Section 18.4, which details the EFI Debug
Support Table feature. This implementation ensures support for
hardware-assisted debugging and provides a standardized mechanism for
debuggers to discover and interact with system-level debug resources.