### PR TITLE
[lib][uefi] Move several memory APIs to uefi_platform.cpp

### DIFF
--- a/lib/uefi/blockio2_protocols.cpp
+++ b/lib/uefi/blockio2_protocols.cpp
@@ -32,6 +32,7 @@
 #include "memory_protocols.h"
 #include "switch_stack.h"
 #include "thread_utils.h"
+#include "uefi_platform.h"
 
 #define LOCAL_TRACE 0
 

--- a/lib/uefi/blockio_protocols.cpp
+++ b/lib/uefi/blockio_protocols.cpp
@@ -25,6 +25,7 @@
 #include "io_stack.h"
 #include "memory_protocols.h"
 #include "switch_stack.h"
+#include "uefi_platform.h"
 
 namespace {
 

--- a/lib/uefi/configuration_table.cpp
+++ b/lib/uefi/configuration_table.cpp
@@ -21,9 +21,9 @@
 #include <string.h>
 #include <uefi/system_table.h>
 
-#include "memory_protocols.h"
-#include "platform.h"
 #include "debug_support.h"
+#include "platform.h"
+#include "uefi_platform.h"
 
 void setup_configuration_table(EfiSystemTable *table) {
   auto &rng = table->configuration_table[table->number_of_table_entries++];
@@ -42,7 +42,8 @@ void setup_configuration_table(EfiSystemTable *table) {
     memcpy(dtb.vendor_table, fdt, fdt_size);
   }
 
-  auto &debug_image_info_table = table->configuration_table[table->number_of_table_entries++];
+  auto &debug_image_info_table =
+      table->configuration_table[table->number_of_table_entries++];
   debug_image_info_table.vendor_guid = EFI_DEBUG_IMAGE_INFO_TABLE_GUID;
   debug_image_info_table.vendor_table = &efi_m_debug_info_table_header;
 }

--- a/lib/uefi/debug_support.cpp
+++ b/lib/uefi/debug_support.cpp
@@ -25,6 +25,7 @@
 
 #include "boot_service_provider.h"
 #include "memory_protocols.h"
+#include "uefi_platform.h"
 
 struct EFI_DEVICE_PATH_FILE_PATH_PROTOCOL {
   struct EFI_DEVICE_PATH_PROTOCOL dp;

--- a/lib/uefi/memory_protocols.h
+++ b/lib/uefi/memory_protocols.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 #ifndef __LIB_UEFI_MEMORY_PROTOCOLS_H
 #define __LIB_UEFI_MEMORY_PROTOCOLS_H
 
@@ -10,14 +27,15 @@ vmm_aspace_t *set_boot_aspace();
 void setup_heap();
 void reset_heap();
 
-void *alloc_page(void *addr, size_t size, size_t align_log2 = PAGE_SIZE_SHIFT);
-void *alloc_page(size_t size, size_t align_log2 = PAGE_SIZE_SHIFT);
-EfiStatus free_pages(EfiPhysicalAddr memory, size_t pages);
-EfiStatus free_pages(void *memory, size_t pages);
-void *identity_map(void *addr, size_t size);
-void *uefi_malloc(size_t size);
-EfiStatus allocate_pool(EfiMemoryType pool_type, size_t size, void **buf);
-EfiStatus free_pool(void *mem);
+EfiStatus allocate_pages(EfiAllocatorType type, EfiMemoryType memory_type,
+                         size_t pages, EfiPhysicalAddr *memory);
+
+// Declaration moved to uefi_platform.h to keep all weak functions declared in
+// one place.
+// void *uefi_malloc(size_t size);
+// EfiStatus allocate_pool(EfiMemoryType pool_type, size_t size, void **buf);
+// EfiStatus free_pool(void *mem);
+// EfiStatus free_pages(void *memory, size_t pages);
 
 EfiStatus get_physical_memory_map(size_t *memory_map_size,
                                   EfiMemoryDescriptor *memory_map,

--- a/lib/uefi/uefi_platform.h
+++ b/lib/uefi/uefi_platform.h
@@ -18,7 +18,9 @@
 #ifndef __GBL_OS_CONFIGURATION_
 #define __GBL_OS_CONFIGURATION_
 
+#include <arch/defines.h>
 #include <uefi/protocols/efi_timestamp_protocol.h>
+#include <uefi/protocols/gbl_efi_image_loading_protocol.h>
 #include <uefi/protocols/gbl_efi_os_configuration_protocol.h>
 #include <uefi/system_table.h>
 #include <uefi/types.h>
@@ -44,5 +46,29 @@ EfiStatus platform_setup_system_table(EfiSystemTable *table);
 uint64_t get_timestamp();
 
 EfiStatus get_timestamp_properties(EfiTimestampProperties *properties);
+
+// alloc_page/free_pages is implemented in memory_protocols.cpp
+void *alloc_page(void *addr, size_t size, size_t align_log2 = PAGE_SIZE_SHIFT);
+
+void *alloc_page(size_t size, size_t align_log2 = PAGE_SIZE_SHIFT);
+
+EfiStatus free_pages(void *memory, size_t pages);
+
+EfiStatus get_buffer(struct GblEfiImageLoadingProtocol *self,
+                     const GblEfiImageInfo *ImageInfo,
+                     GblEfiImageBuffer *Buffer);
+
+// uefi_malloc is used by LK to allocate memory that would be used by UEFI
+// applications
+void *uefi_malloc(size_t size);
+
+// Used by UEFI application to allocate heap memory.
+EfiStatus allocate_pool(EfiMemoryType pool_type, size_t size, void **buf);
+EfiStatus free_pool(void *mem);
+
+// Called by LK once before executing UEFI application to setup the heap
+void setup_heap();
+// Caled by LK once after executing UEFI application to tear down the heap
+void reset_heap();
 
 #endif


### PR DESCRIPTION
This allows OEMs to customize exactly how their memories are allocated. For examples, OEMs might want to allocate certain parts of the UEFI from high address kernel space, for ease of access in LK world. Since UEFI spec requires everything to be identity mapped, the default implementation of memory allocation is identity mapped.