### PR TITLE
[lib][uefi] Fix LTRACEF logging

### DIFF
--- a/lib/uefi/memory_protocols.cpp
+++ b/lib/uefi/memory_protocols.cpp
@@ -158,8 +158,8 @@ EfiStatus allocate_pages(EfiAllocatorType type, EfiMemoryType memory_type,
     return INVALID_PARAMETER;
   }
   if (type == ALLOCATE_MAX_ADDRESS && *memory < 0xFFFFFFFF) {
-    LTRACEF("%s(%d, %d, %zu, 0x%llx) unsupported\n", __FUNCTION__, type,
-            memory_type, pages, *memory);
+    LTRACEF("%d, %d, %zu, 0x%llx unsupported\n", type, memory_type, pages,
+            *memory);
     return UNSUPPORTED;
   }
   *memory = reinterpret_cast<EfiPhysicalAddr>(alloc_page(pages * PAGE_SIZE));


### PR DESCRIPTION
LTRACEF already outputs function name, no need to do it again