### PR TITLE
fix link script not include global array init

### DIFF
--- a/arch/arm/system-onesegment.ld
+++ b/arch/arm/system-onesegment.ld
@@ -76,12 +76,12 @@ SECTIONS
 
     .ctors : ALIGN(4) {
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
     }
     .dtors : ALIGN(4) {
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
     }
     .got : { *(.got.plt) *(.got) }

--- a/arch/arm/system-twosegment.ld
+++ b/arch/arm/system-twosegment.ld
@@ -84,12 +84,12 @@ SECTIONS
     }
     .ctors : ALIGN(4) {
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
     }
     .dtors : ALIGN(4) {
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
     }
     .got : { *(.got.plt) *(.got) }

--- a/arch/arm64/system-onesegment.ld
+++ b/arch/arm64/system-onesegment.ld
@@ -78,12 +78,12 @@ SECTIONS
 
     .ctors : ALIGN(8) {
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
     }
     .dtors : ALIGN(8) {
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
     }
     .got : { *(.got.plt) *(.got) }

--- a/arch/m68k/linker.ld
+++ b/arch/m68k/linker.ld
@@ -40,10 +40,10 @@ SECTIONS
         __data_start = .;
         *(.data .data.* .gnu.linkonce.d.*)
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
         *(.got*)
         *(.dynamic)

--- a/arch/microblaze/linker.ld
+++ b/arch/microblaze/linker.ld
@@ -72,10 +72,10 @@ SECTIONS
         __data_start = .;
         *(.data .data.* .gnu.linkonce.d.*)
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
         *(.got*)
         *(.dynamic)

--- a/arch/mips/linker.ld
+++ b/arch/mips/linker.ld
@@ -74,10 +74,10 @@ SECTIONS
         __data_start = .;
         *(.data .data.* .gnu.linkonce.d.*)
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
         *(.got*)
         *(.dynamic)

--- a/arch/or1k/linker.ld
+++ b/arch/or1k/linker.ld
@@ -62,10 +62,10 @@ SECTIONS
         __data_start = .;
         *(.data .data.* .gnu.linkonce.d.*)
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
         *(.got*)
         *(.dynamic)

--- a/arch/riscv/linker-onesegment.ld
+++ b/arch/riscv/linker-onesegment.ld
@@ -44,10 +44,10 @@ SECTIONS
         __data_start = .;
         *(.data .data.* .gnu.linkonce.d.*)
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
         *(.got*)
         *(.dynamic)

--- a/arch/riscv/linker-twosegment.ld
+++ b/arch/riscv/linker-twosegment.ld
@@ -56,10 +56,10 @@ SECTIONS
         __data_start = .;
         *(.data .data.* .gnu.linkonce.d.*)
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
         *(.got*)
         *(.dynamic)

--- a/arch/x86/32/kernel.ld
+++ b/arch/x86/32/kernel.ld
@@ -59,12 +59,12 @@ SECTIONS
 
     .ctors : ALIGN(4) {
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
     }
     .dtors : ALIGN(4) {
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
     }
 

--- a/arch/x86/64/kernel.ld
+++ b/arch/x86/64/kernel.ld
@@ -59,12 +59,12 @@ SECTIONS
 
     .ctors : ALIGN(4) {
         __ctor_list = .;
-        KEEP(*(.ctors .init_array))
+        KEEP(*(.ctors .init_array*))
         __ctor_end = .;
     }
     .dtors : ALIGN(4) {
         __dtor_list = .;
-        KEEP(*(.dtors .fini_array))
+        KEEP(*(.dtors .fini_array*))
         __dtor_end = .;
     }
 


### PR DESCRIPTION
Using wild match init_array* to include global array init ctor

Before:

 10 .ctors             00000040 ffff0000001e6b80 00000000401e6b80 DATA
 11 .dtors             00000000 ffff0000001e6bc0 00000000401e6bc0 DATA
 12 .got               00000060 ffff0000001e6bc0 00000000401e6bc0 DATA
 13 .init_array.1      00000470 ffff0000001e6c20 00000000401e6c20
 14 .fini_array.1      00000470 ffff0000001e7090 00000000401e7090
 15 .dummy_post_data   00000000 ffff0000001e7500 00000000401e7500 DATA
 16 .bss               00009460 ffff0000001e8000 00000000401e8000 BSS

After:

 10 .ctors             000004b0 ffff0000001e6b80 00000000401e6b80 DATA
 11 .dtors             00000470 ffff0000001e7030 00000000401e7030
 12 .got               00000060 ffff0000001e74a0 00000000401e74a0 DATA
 13 .dummy_post_data   00000000 ffff0000001e7500 00000000401e7500 DATA
 14 .bss               00009460 ffff0000001e8000 00000000401e8000 BSS