### PR TITLE
[lib][uefi] events.cpp: Fix unintended create_event() logic change

### DIFF
--- a/lib/uefi/events.cpp
+++ b/lib/uefi/events.cpp
@@ -150,7 +150,8 @@ EfiStatus create_event(EfiEventType type, EfiTpl notify_tpl,
     printf("Creating timer event is not supported yet\n");
     return EFI_STATUS_UNSUPPORTED;
   }
-  if (type & (EFI_EVENT_TYPE_SIGNAL_EXIT_BOOT_SERVICES | EFI_EVENT_TYPE_SIGNAL_VIRTUAL_ADDRESS_CHANGE)) {
+  if (type == EFI_EVENT_TYPE_SIGNAL_EXIT_BOOT_SERVICES ||
+      type == EFI_EVENT_TYPE_SIGNAL_VIRTUAL_ADDRESS_CHANGE) {
     printf(
         "Creating SIGNAL_EXIT_BOOT_SERVICES or SIGNAL_VIRTUAL_ADDRESS_CHANGE "
         "event is not supported yet 0x%x\n",


### PR DESCRIPTION
In b1e26e90cd94ccea2c7ea6c4f3d7d5f81b3dd111 I mistakenly modified the flag comparison logic from
```
if ((type & SIGNAL_EXIT_BOOT_SERVICES) == SIGNAL_EXIT_BOOT_SERVICES)
```
to
```
if (type & SIGNAL_EXIT_BOOT_SERVICES)
```

However `SIGNAL_EXIT_BOOT_SERVICES` is actually a set of multiple bit flags, so the new logic is not equivalent to the original code.

Instead change the comparison logic to just
```
if (type == SIGNAL_EXIT_BOOT_SERVICES)
```
as the UEFI says `EVT_SIGNAL_EXIT_BOOT_SERVICES` and `EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE` mustn't be combined with any other flags.