### PR TITLE
[app][tests] Change 'buf_in' to unsigned char for cbuf_tests

### DIFF
--- a/app/tests/cbuf_tests.c
+++ b/app/tests/cbuf_tests.c
@@ -99,7 +99,7 @@ int cbuf_tests(int argc, const console_cmd_args *argv) {
 
         // Read up to 8 bytes, make sure they are right.
         if (pos_in < pos_out) {
-            char buf_in[8];
+            unsigned char buf_in[8];
             int to_read_random = rand() & 7;
             int to_read = MIN(to_read_random, pos_out - pos_in);
             int read = cbuf_read(&cbuf, buf_in, to_read, false);


### PR DESCRIPTION
] cbuf_tests
running basic tests...
running random tests...
panic (caller 0x28e0): 128 != 4294967168 (app/tests/cbuf_tests.c:109)
CRASH: starting debug shell, reason 'software panic'
entering panic shell loop
! 


cbuf_tests fails on m68k due to 'char' being signed. This commit switches 'buf_in' to unsigned char.

Not sure if 'buf' and 'buf_out' should also be switched to unsigned; the test passes with changes to just buf_in.