### PR TITLE
[lib][gfx] Add mono 1bpp support

### DIFF
--- a/arch/m68k/arch.c
+++ b/arch/m68k/arch.c
@@ -50,7 +50,7 @@ void arch_chain_load(void *entry, ulong arg0, ulong arg1, ulong arg2, ulong arg3
 void arch_disable_cache(uint flags) { PANIC_UNIMPLEMENTED; }
 void arch_enable_cache(uint flags) { PANIC_UNIMPLEMENTED; }
 
-void arch_clean_cache_range(addr_t start, size_t len) { PANIC_UNIMPLEMENTED; }
+void arch_clean_cache_range(addr_t start, size_t len) {  } // TODO: may need to implement this later
 void arch_clean_invalidate_cache_range(addr_t start, size_t len) { PANIC_UNIMPLEMENTED; }
 void arch_invalidate_cache_range(addr_t start, size_t len) { PANIC_UNIMPLEMENTED; }
 void arch_sync_cache_range(addr_t start, size_t len) { PANIC_UNIMPLEMENTED; }

--- a/lib/font/font.c
+++ b/lib/font/font.c
@@ -16,9 +16,9 @@
  * @ingroup graphics
  */
 
-#include <lk/debug.h>
-#include <lib/gfx.h>
 #include <lib/font.h>
+#include <lib/gfx.h>
+#include <lk/debug.h>
 
 #include "font.h"
 
@@ -28,19 +28,47 @@
  * @ingroup graphics
  */
 void font_draw_char(gfx_surface *surface, unsigned char c, int x, int y, uint32_t color) {
-    uint i,j;
+    uint i, j;
     uint line;
 
-    // draw this char into a buffer
+    // 1bpp batched per-byte, for performance boost
+    if (surface->format == GFX_FORMAT_MONO_1 && surface->spanmono1) {
+        uint32_t c1 = surface->translate_color ? surface->translate_color(color) : color;
+        gfx_span_op op = (c1 != 0) ? GFX_SPAN_SET : GFX_SPAN_CLR;
+
+        for (i = 0; i < FONT_Y; i++) {
+            line = FONT[(c * FONT_Y) + i];
+
+            for (j = 0; j < FONT_X;) {
+                if ((line & 0x1) == 0) {
+                    line >>= 1;
+                    j++;
+                    continue;
+                }
+
+                uint start = j;
+                do {
+                    line >>= 1;
+                    j++;
+                } while (j < FONT_X && (line & 0x1));
+
+                surface->spanmono1(surface, (x + start), (y + i), (j - start), op);
+            }
+        }
+
+        gfx_flush_rows(surface, y, (y + FONT_Y));
+        return;
+    }
+
+    // Per-pixel default
     for (i = 0; i < FONT_Y; i++) {
-        line = FONT[c * FONT_Y + i];
+        line = FONT[(c * FONT_Y) + i];
         for (j = 0; j < FONT_X; j++) {
-            if (line & 0x1)
-                gfx_putpixel(surface, x + j, y + i, color);
+            if (line & 0x1) {
+                gfx_putpixel(surface, (x + j), (y + i), color);
+            }
             line = line >> 1;
         }
     }
-    gfx_flush_rows(surface, y, y + FONT_Y);
+    gfx_flush_rows(surface, y, (y + FONT_Y));
 }
-
-

--- a/lib/gfx/include/lib/gfx.h
+++ b/lib/gfx/include/lib/gfx.h
@@ -7,10 +7,10 @@
  */
 #pragma once
 
-#include <stdbool.h>
-#include <sys/types.h>
 #include <inttypes.h>
 #include <lk/compiler.h>
+#include <stdbool.h>
+#include <sys/types.h>
 
 // gfx library
 
@@ -24,10 +24,17 @@ typedef enum {
     GFX_FORMAT_RGB_2220,
     GFX_FORMAT_ARGB_8888,
     GFX_FORMAT_RGB_x888,
+    GFX_FORMAT_MONO_1,
     GFX_FORMAT_MONO,
 
     GFX_FORMAT_MAX
 } gfx_format;
+
+typedef enum {
+    GFX_SPAN_SET = 0,
+    GFX_SPAN_CLR = 1,
+    GFX_SPAN_TOGGLE = 2,
+} gfx_span_op;
 
 #define MAX_ALPHA 255
 
@@ -55,6 +62,7 @@ typedef struct gfx_surface {
     uint32_t (*translate_color)(uint32_t input);
     void (*copyrect)(struct gfx_surface *, uint x, uint y, uint width, uint height, uint x2, uint y2);
     void (*fillrect)(struct gfx_surface *, uint x, uint y, uint width, uint height, uint color);
+    void (*spanmono1)(struct gfx_surface *, uint x, uint y, uint width, gfx_span_op op);
     void (*putpixel)(struct gfx_surface *, uint x, uint y, uint color);
     void (*flush)(uint starty, uint endy);
 } gfx_surface;
@@ -75,8 +83,9 @@ void gfx_line(gfx_surface *surface, uint x1, uint y1, uint x2, uint y2, uint col
 static inline void gfx_clear(gfx_surface *surface, uint color) {
     surface->fillrect(surface, 0, 0, surface->width, surface->height, color);
 
-    if (surface->flush)
-        surface->flush(0, surface->height-1);
+    if (surface->flush) {
+        surface->flush(0, surface->height - 1);
+    }
 }
 
 // blend between two surfaces
@@ -104,4 +113,3 @@ void gfx_draw_pattern(void);
 void gfx_draw_pattern_white(void);
 
 __END_CDECLS
-


### PR DESCRIPTION
[lib][font] Use mono 1bpp byte-span drawing, where available

- Adds 1bpp rendering function, and accompanying implementations of putpixel, copyrect, fillrect.

- libgfx now calls arch_clean_cache_range() conditionally, to avoid crashes on architectures lacking cache support.

- Includes changes made by scripts/codestyle