### PR TITLE
[lib][libc] Fix fclose condition for fs-backed streams

### DIFF
--- a/lib/libc/stdio.c
+++ b/lib/libc/stdio.c
@@ -73,7 +73,7 @@ FILE *fopen(const char *filename, const char *mode) {
 
 int fclose(FILE *stream) {
 #if defined(WITH_LIB_FS)
-    if (stream && !stream->use_fs) {
+    if (stream && stream->use_fs) {
         fs_close_file(stream->fs_handle.handle);
         free(stream);
     }


### PR DESCRIPTION
`fopen()` marks filesystem-backed streams with `use_fs = true`, but `fclose()`
checks the inverse condition before cleanup.

Fix the condition so `fclose()` closes and frees FS-backed streams correctly.