### PR TITLE
[lib][fs] Fix cleanup on handle allocation failure

### DIFF
--- a/lib/fs/fs.c
+++ b/lib/fs/fs.c
@@ -266,6 +266,11 @@ status_t fs_open_file(const char *path, filehandle **handle) {
     }
 
     filehandle *f = malloc(sizeof(*f));
+    if (!f) {
+        mount->api->close(cookie);
+        put_mount(mount);
+        return ERR_NO_MEMORY;
+    }
     f->cookie = cookie;
     f->mount = mount;
     *handle = f;
@@ -309,8 +314,9 @@ status_t fs_create_file(const char *path, filehandle **handle, uint64_t len) {
 
     filehandle *f = malloc(sizeof(*f));
     if (!f) {
+        mount->api->close(cookie);
         put_mount(mount);
-        return err;
+        return ERR_NO_MEMORY;
     }
     f->cookie = cookie;
     f->mount = mount;
@@ -425,6 +431,7 @@ status_t fs_open_dir(const char *path, dirhandle **handle) {
 
     dirhandle *d = malloc(sizeof(*d));
     if (!d) {
+        mount->api->closedir(cookie);
         put_mount(mount);
         return ERR_NO_MEMORY;
     }

--- a/lib/libc/stdio.c
+++ b/lib/libc/stdio.c
@@ -73,7 +73,7 @@ FILE *fopen(const char *filename, const char *mode) {
 
 int fclose(FILE *stream) {
 #if defined(WITH_LIB_FS)
-    if (stream && !stream->use_fs) {
+    if (stream && stream->use_fs) {
         fs_close_file(stream->fs_handle.handle);
         free(stream);
     }


### PR DESCRIPTION
When `fs_open_file()`, `fs_create_file()`, or `fs_open_dir()` fail to allocate
their wrapper handle objects, they should release the already-opened file or
directory cookie before dropping the mount reference.

Also return `ERR_NO_MEMORY` from `fs_create_file()` on allocation failure.