### PR TITLE
[platform][zynq] Check for CFI buffer allocation failure

### DIFF
--- a/lib/fs/fs.c
+++ b/lib/fs/fs.c
@@ -266,6 +266,11 @@ status_t fs_open_file(const char *path, filehandle **handle) {
     }
 
     filehandle *f = malloc(sizeof(*f));
+    if (!f) {
+        mount->api->close(cookie);
+        put_mount(mount);
+        return ERR_NO_MEMORY;
+    }
     f->cookie = cookie;
     f->mount = mount;
     *handle = f;
@@ -309,8 +314,9 @@ status_t fs_create_file(const char *path, filehandle **handle, uint64_t len) {
 
     filehandle *f = malloc(sizeof(*f));
     if (!f) {
+        mount->api->close(cookie);
         put_mount(mount);
-        return err;
+        return ERR_NO_MEMORY;
     }
     f->cookie = cookie;
     f->mount = mount;
@@ -425,6 +431,7 @@ status_t fs_open_dir(const char *path, dirhandle **handle) {
 
     dirhandle *d = malloc(sizeof(*d));
     if (!d) {
+        mount->api->closedir(cookie);
         put_mount(mount);
         return ERR_NO_MEMORY;
     }

--- a/lib/libc/stdio.c
+++ b/lib/libc/stdio.c
@@ -73,7 +73,7 @@ FILE *fopen(const char *filename, const char *mode) {
 
 int fclose(FILE *stream) {
 #if defined(WITH_LIB_FS)
-    if (stream && !stream->use_fs) {
+    if (stream && stream->use_fs) {
         fs_close_file(stream->fs_handle.handle);
         free(stream);
     }

--- a/platform/zynq/spiflash.c
+++ b/platform/zynq/spiflash.c
@@ -207,6 +207,10 @@ status_t spiflash_detect(void) {
 
     /* read and parse the cfi */
     uint8_t *buf = calloc(1, 512);
+    if (!buf) {
+        flash.detected = false;
+        return ERR_NO_MEMORY;
+    }
     ssize_t len = spiflash_read_cfi(buf, 512);
     if (len < 4)
         goto nodetect;


### PR DESCRIPTION
Check the CFI buffer allocation result in `spiflash_detect()` before using it.

Return `ERR_NO_MEMORY` when the temporary buffer cannot be allocated.