### PR TITLE
[lib][fdtwalk] fix unaligned FDT memory reservation

### DIFF
--- a/lib/fdtwalk/helpers.cpp
+++ b/lib/fdtwalk/helpers.cpp
@@ -51,11 +51,11 @@ status_t fdtwalk_reserve_fdt_memory(const void *fdt, paddr_t fdt_phys) {
         return ERR_NOT_FOUND;
     }
 
-    uint32_t length = fdt_totalsize(fdt);
+    size_t length = fdt_totalsize(fdt);
 
-    paddr_t base = fdt_phys;
-    base = PAGE_ALIGN(base);
-    length = ROUNDUP(length, PAGE_SIZE);
+    paddr_t base = ROUNDDOWN(fdt_phys, PAGE_SIZE);
+    size_t offset = fdt_phys - base;
+    length = ROUNDUP(length + offset, PAGE_SIZE);
 
     dprintf(INFO, "FDT: reserving physical range for FDT: [%#lx, %#lx]\n", base, base + length - 1);
 


### PR DESCRIPTION
Reserve the full page range that covers the FDT byte range.

The previous calculation rounded the base up and the size up separately,
which could miss the first page when the FDT physical address was not
page aligned.

Fix this by rounding the base down to the containing page boundary and
including the resulting offset in the length calculation.