### PR TITLE
[lib][uefi] implement missing protocols required by GBL

### DIFF
--- a/lib/uefi/blockio_protocols.cpp
+++ b/lib/uefi/blockio_protocols.cpp
@@ -103,21 +103,38 @@ __WEAK EfiStatus open_block_device(EfiHandle handle, const void** intf) {
   return EFI_STATUS_SUCCESS;
 }
 
-EfiStatus list_block_devices(size_t *num_handles, EfiHandle **buf) {
+EfiStatus list_block_devices(size_t *num_handles, EfiHandle *buf) {
+  if (num_handles == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+
   size_t device_count = 0;
   bio_iter_devices([&device_count](bdev_t *dev) {
     device_count++;
     return true;
   });
-  auto devices =
-      reinterpret_cast<EfiHandle *>(uefi_malloc(sizeof(EfiHandle) * device_count));
+
+  if (device_count == 0) {
+    *num_handles = 0;
+    return EFI_STATUS_NOT_FOUND;
+  }
+
+  if (*num_handles < device_count) {
+    *num_handles = device_count;
+    return EFI_STATUS_BUFFER_TOO_SMALL;
+  }
+
+  // Allow null buffers for size queries, but require storage before writing.
+  if (buf == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+
   size_t i = 0;
-  bio_iter_devices([&i, devices, device_count](bdev_t *dev) {
-    devices[i] = dev->name;
+  bio_iter_devices([&i, buf, device_count](bdev_t *dev) {
+    buf[i] = dev->name;
     i++;
     return i < device_count;
   });
   *num_handles = i;
-  *buf = devices;
   return EFI_STATUS_SUCCESS;
 }

--- a/lib/uefi/blockio_protocols.h
+++ b/lib/uefi/blockio_protocols.h
@@ -5,6 +5,6 @@
 
 EfiStatus open_block_device(EfiHandle handle, const void **intf);
 
-EfiStatus list_block_devices(size_t *num_handles, EfiHandle **buf);
+EfiStatus list_block_devices(size_t *num_handles, EfiHandle *buf);
 
 #endif

--- a/lib/uefi/boot_service_provider.cpp
+++ b/lib/uefi/boot_service_provider.cpp
@@ -16,6 +16,7 @@
  */
 #include "boot_service_provider.h"
 
+#include <endian.h>
 #include <lk/compiler.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,6 +40,63 @@
 
 namespace {
 
+bool guid_eq(const EfiGuid *a, const EfiGuid *b) {
+  if (a == nullptr || b == nullptr) {
+    return false;
+  }
+  return memcmp(a, b, sizeof(*a)) == 0;
+}
+
+bool guid_eq(const EfiGuid *a, const EfiGuid &b) {
+  return guid_eq(a, &b);
+}
+
+const char *protocol_name(const EfiGuid *protocol) {
+  if (protocol == nullptr) {
+    return nullptr;
+  }
+
+  struct ProtocolGuidName {
+    const EfiGuid *guid;
+    const char *name;
+  };
+  static constexpr ProtocolGuidName kProtocolGuidNames[] = {
+      {&LOADED_IMAGE_PROTOCOL_GUID, "LOADED_IMAGE_PROTOCOL_GUID"},
+      {&EFI_DEVICE_PATH_PROTOCOL_GUID, "EFI_DEVICE_PATH_PROTOCOL_GUID"},
+      {&LINUX_EFI_LOADED_IMAGE_FIXED_GUID,
+       "LINUX_EFI_LOADED_IMAGE_FIXED_GUID"},
+      {&EFI_RNG_PROTOCOL_GUID, "EFI_RNG_PROTOCOL_GUID"},
+      {&EFI_TCG2_PROTOCOL_GUID, "EFI_TCG2_PROTOCOL_GUID"},
+      {&EFI_LOAD_FILE2_PROTOCOL_GUID, "EFI_LOAD_FILE2_PROTOCOL_GUID"},
+      {&EFI_BLOCK_IO_PROTOCOL_GUID, "EFI_BLOCK_IO_PROTOCOL_GUID"},
+      {&EFI_BLOCK_IO2_PROTOCOL_GUID, "EFI_BLOCK_IO2_PROTOCOL_GUID"},
+      {&EFI_TEXT_INPUT_PROTOCOL_GUID, "EFI_TEXT_INPUT_PROTOCOL_GUID"},
+      {&EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID,
+       "EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID"},
+      {&EFI_GBL_EFI_IMAGE_LOADING_PROTOCOL_GUID,
+       "EFI_GBL_EFI_IMAGE_LOADING_PROTOCOL_GUID"},
+      {&EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID,
+       "EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID"},
+      {&EFI_GBL_EFI_AVB_PROTOCOL_GUID, "EFI_GBL_EFI_AVB_PROTOCOL_GUID"},
+      {&EFI_GBL_EFI_FASTBOOT_PROTOCOL_GUID,
+       "EFI_GBL_EFI_FASTBOOT_PROTOCOL_GUID"},
+      {&EFI_GBL_EFI_FASTBOOT_TRANSPORT_PROTOCOL_GUID,
+       "EFI_GBL_EFI_FASTBOOT_TRANSPORT_PROTOCOL_GUID"},
+      {&EFI_DT_FIXUP_PROTOCOL_GUID, "EFI_DT_FIXUP_PROTOCOL_GUID"},
+      {&EFI_TIMESTAMP_PROTOCOL_GUID, "EFI_TIMESTAMP_PROTOCOL_GUID"},
+      {&EFI_BOOT_MEMORY_PROTOCOL_GUID, "EFI_BOOT_MEMORY_PROTOCOL_GUID"},
+      {&EFI_ERASE_BLOCK_PROTOCOL_GUID, "EFI_ERASE_BLOCK_PROTOCOL_GUID"},
+  };
+
+  for (const auto &entry : kProtocolGuidNames) {
+    if (guid_eq(protocol, entry.guid)) {
+      return entry.name;
+    }
+  }
+
+  return nullptr;
+}
+
 EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, const void **intf,
                         EfiHandle agent_handle, EfiHandle controller_handle,
                         EfiOpenProtocolAttributes attr);
@@ -47,41 +105,56 @@ EfiStatus locate_handle_buffer(EfiLocateHandleSearchType search_type,
                                const EfiGuid *protocol, const void *search_key,
                                size_t *num_handles, EfiHandle **buf);
 
+uint64_t guid_data4(const EfiGuid *guid) {
+  uint64_t data4 = 0;
+  memcpy(&data4, guid->data4, sizeof(data4));
+  return LE64(data4);
+}
+
+const char *fmt_guid(const EfiGuid *protocol, char *buf, size_t buf_size) {
+  const char *name = protocol_name(protocol);
+  if (name != nullptr) {
+    return name;
+  }
+  if (protocol == nullptr) {
+    return "nullptr";
+  }
+  snprintf(buf, buf_size, "(0x%x 0x%x 0x%x 0x%llx)", protocol->data1,
+           protocol->data2, protocol->data3,
+           static_cast<unsigned long long>(guid_data4(protocol)));
+  return buf;
+}
+
 EfiStatus unload(EfiHandle handle) { return EFI_STATUS_SUCCESS; }
 
-bool guid_eq(const EfiGuid *a, const EfiGuid *b) {
-  return memcmp(a, b, sizeof(*a)) == 0;
-}
-
-bool guid_eq(const EfiGuid *a, const EfiGuid &b) {
-  return memcmp(a, &b, sizeof(*a)) == 0;
-}
-
 EfiHandle singleton_protocol_handle(const EfiGuid *protocol) {
-  if (guid_eq(protocol, EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID)) {
-    return &EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID;
-  } else if (guid_eq(protocol, EFI_DT_FIXUP_PROTOCOL_GUID)) {
-    return &EFI_DT_FIXUP_PROTOCOL_GUID;
-  } else if (guid_eq(protocol, EFI_TIMESTAMP_PROTOCOL_GUID)) {
-    return &EFI_TIMESTAMP_PROTOCOL_GUID;
-  } else if (guid_eq(protocol, EFI_BOOT_MEMORY_PROTOCOL_GUID)) {
-    return &EFI_BOOT_MEMORY_PROTOCOL_GUID;
-  } else if (guid_eq(protocol, EFI_GBL_EFI_AVB_PROTOCOL_GUID)) {
-    return &EFI_GBL_EFI_AVB_PROTOCOL_GUID;
-  } else if (guid_eq(protocol, EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID)) {
-    return &EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID;
-  } else if (guid_eq(protocol, EFI_RNG_PROTOCOL_GUID)) {
-    return &EFI_RNG_PROTOCOL_GUID;
+  static constexpr const EfiGuid *kSingletonGuids[] = {
+      &EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID,
+      &EFI_DT_FIXUP_PROTOCOL_GUID,
+      &EFI_TIMESTAMP_PROTOCOL_GUID,
+      &EFI_BOOT_MEMORY_PROTOCOL_GUID,
+      &EFI_GBL_EFI_AVB_PROTOCOL_GUID,
+      &EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID,
+      &EFI_RNG_PROTOCOL_GUID,
+  };
+
+  for (const EfiGuid *singleton_guid : kSingletonGuids) {
+    if (guid_eq(protocol, singleton_guid)) {
+      return singleton_guid;
+    }
   }
   return nullptr;
 }
 
 EfiStatus handle_protocol(EfiHandle handle, const EfiGuid *protocol,
                           void **intf) {
+  char name_buf[64];
+  printf("%s(%p, %s, %p);\n", __FUNCTION__, handle,
+         fmt_guid(protocol, name_buf, sizeof(name_buf)), intf);
+
   if (guid_eq(protocol, LOADED_IMAGE_PROTOCOL_GUID)) {
-    printf("handle_protocol(%p, LOADED_IMAGE_PROTOCOL_GUID, %p);\n", handle,
-           intf);
-    const auto loaded_image = static_cast<EfiLoadedImageProtocol *>(uefi_malloc(sizeof(EfiLoadedImageProtocol)));
+    const auto loaded_image = static_cast<EfiLoadedImageProtocol *>(
+        uefi_malloc(sizeof(EfiLoadedImageProtocol)));
     if (!loaded_image) {
       return EFI_STATUS_OUT_OF_RESOURCES;
     }
@@ -97,18 +170,16 @@ EfiStatus handle_protocol(EfiHandle handle, const EfiGuid *protocol,
     *intf = loaded_image;
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, LINUX_EFI_LOADED_IMAGE_FIXED_GUID)) {
-    printf("handle_protocol(%p, LINUX_EFI_LOADED_IMAGE_FIXED_GUID, %p);\n",
-           handle, intf);
     return EFI_STATUS_UNSUPPORTED;
-  } else {
-    printf("handle_protocol(%p, %p, %p);\n", handle, protocol, intf);
   }
   return EFI_STATUS_UNSUPPORTED;
 }
 
 EfiStatus register_protocol_notify(const EfiGuid *protocol, EfiEvent event,
                                    void **registration) {
-  printf("%s is unsupported\n", __FUNCTION__);
+  char name_buf[64];
+  printf("%s(%s, event=%p, registration=%p) is unsupported\n", __FUNCTION__,
+         fmt_guid(protocol, name_buf, sizeof(name_buf)), event, registration);
   return EFI_STATUS_UNSUPPORTED;
 }
 
@@ -126,20 +197,18 @@ EfiStatus locate_handle(EfiLocateHandleSearchType search_type,
       *buf_size = num_handles * sizeof(EfiHandle);
       return status;
     }
-    printf("%s(0x%x, EFI_BLOCK_IO_PROTOCOL_GUID, search_key=%p)\n",
-           __FUNCTION__, search_type, search_key);
+    char name_buf[64];
+    printf("%s(0x%x, %s, search_key=%p)\n", __FUNCTION__, search_type,
+           fmt_guid(protocol, name_buf, sizeof(name_buf)), search_key);
     return EFI_STATUS_UNSUPPORTED;
-  } else if (guid_eq(protocol, EFI_TEXT_INPUT_PROTOCOL_GUID)) {
-    printf("%s(0x%x, EFI_TEXT_INPUT_PROTOCOL_GUID, search_key=%p)\n",
-           __FUNCTION__, search_type, search_key);
-    return EFI_STATUS_NOT_FOUND;
   }
 
   const EfiHandle singleton_handle = singleton_protocol_handle(protocol);
-  if (singleton_handle != nullptr) {
-    printf("%s(0x%x, %p, search_key=%p)\n", __FUNCTION__, search_type, protocol,
-           search_key);
+  char name_buf[64];
+  printf("%s(0x%x, %s, search_key=%p)\n", __FUNCTION__, search_type,
+         fmt_guid(protocol, name_buf, sizeof(name_buf)), search_key);
 
+  if (singleton_handle != nullptr) {
     const size_t required_size = sizeof(EfiHandle);
     if (*buf_size < required_size) {
       *buf_size = required_size;
@@ -147,15 +216,13 @@ EfiStatus locate_handle(EfiLocateHandleSearchType search_type,
     }
 
     *buf_size = required_size;
-    if (buf != nullptr) {
-      *buf = singleton_handle;
+    if (buf == nullptr) {
+      return EFI_STATUS_INVALID_PARAMETER;
     }
+    *buf = singleton_handle;
     return EFI_STATUS_SUCCESS;
   }
 
-  printf("%s(0x%x, (0x%x 0x%x 0x%x 0x%llx), search_key=%p)\n", __FUNCTION__,
-         search_type, protocol->data1, protocol->data2, protocol->data3,
-         *(uint64_t *)&protocol->data4, search_key);
   return EFI_STATUS_NOT_FOUND;
 }
 
@@ -171,18 +238,19 @@ EfiStatus locate_protocol(const EfiGuid *protocol, void *registration,
                          nullptr, nullptr, 0);
   }
 
-  if (memcmp(protocol, &EFI_RNG_PROTOCOL_GUID, sizeof(*protocol)) == 0) {
-    printf("%s(EFI_RNG_PROTOCOL_GUID) is unsupported.\n", __FUNCTION__);
+  char name_buf[64];
+  const char *name = fmt_guid(protocol, name_buf, sizeof(name_buf));
+
+  if (guid_eq(protocol, EFI_RNG_PROTOCOL_GUID)) {
+    printf("%s(%s) is unsupported.\n", __FUNCTION__, name);
     return EFI_STATUS_UNSUPPORTED;
   }
-  if (memcmp(protocol, &EFI_TCG2_PROTOCOL_GUID, sizeof(*protocol)) == 0) {
-    printf("%s(EFI_TCG2_PROTOCOL_GUID) is unsupported.\n", __FUNCTION__);
+  if (guid_eq(protocol, EFI_TCG2_PROTOCOL_GUID)) {
+    printf("%s(%s) is unsupported.\n", __FUNCTION__, name);
     return EFI_STATUS_NOT_FOUND;
   }
 
-  printf("%s(%x %x %x %llx) is unsupported\n", __FUNCTION__, protocol->data1,
-         protocol->data2, protocol->data3,
-         *reinterpret_cast<const uint64_t *>(&protocol->data4));
+  printf("%s(%s) is unsupported\n", __FUNCTION__, name);
   return EFI_STATUS_NOT_FOUND;
 }
 
@@ -197,7 +265,9 @@ EfiStatus calculate_crc32(void *data, size_t len, uint32_t *crc32) {
 
 EfiStatus uninstall_protocol_interface(EfiHandle handle,
                                        const EfiGuid *protocol, void *intf) {
-  printf("%s is unsupported\n", __FUNCTION__);
+  char name_buf[64];
+  printf("%s(%s, handle=%p, intf=%p) is unsupported\n", __FUNCTION__,
+         fmt_guid(protocol, name_buf, sizeof(name_buf)), handle, intf);
   return EFI_STATUS_UNSUPPORTED;
 }
 
@@ -210,11 +280,12 @@ EfiStatus load_image(bool boot_policy, EfiHandle parent_image_handle,
 
 EfiStatus locate_device_path(const EfiGuid *protocol,
                              EfiDevicePathProtocol **path, EfiHandle *device) {
-  if (memcmp(protocol, &EFI_LOAD_FILE2_PROTOCOL_GUID,
-             sizeof(EFI_LOAD_FILE2_PROTOCOL_GUID)) == 0) {
+  if (guid_eq(protocol, EFI_LOAD_FILE2_PROTOCOL_GUID)) {
     return EFI_STATUS_NOT_FOUND;
   }
-  printf("%s is unsupported\n", __FUNCTION__);
+  char name_buf[64];
+  printf("%s(%s) is unsupported\n", __FUNCTION__,
+         fmt_guid(protocol, name_buf, sizeof(name_buf)));
   return EFI_STATUS_UNSUPPORTED;
 }
 
@@ -240,36 +311,30 @@ void restore_tpl(EfiTpl old_tpl) {
 EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, const void **intf,
                         EfiHandle agent_handle, EfiHandle controller_handle,
                         EfiOpenProtocolAttributes attr) {
+  char name_buf[64];
+  printf("%s(%s, handle=%p, agent_handle=%p, controller_handle=%p, "
+         "attr=0x%x)\n",
+         __FUNCTION__, fmt_guid(protocol, name_buf, sizeof(name_buf)), handle,
+         agent_handle, controller_handle, attr);
+
   if (guid_eq(protocol, LOADED_IMAGE_PROTOCOL_GUID)) {
     auto interface = reinterpret_cast<EfiLoadedImageProtocol *>(
         uefi_malloc(sizeof(EfiLoadedImageProtocol)));
+    if (interface == nullptr) {
+      return EFI_STATUS_OUT_OF_RESOURCES;
+    }
     memset(interface, 0, sizeof(*interface));
     interface->parent_handle = handle;
     interface->image_base = handle;
     *intf = interface;
-    printf("%s(LOADED_IMAGE_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p, attr=0x%x)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle, attr);
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_DEVICE_PATH_PROTOCOL_GUID)) {
-    printf("%s(EFI_DEVICE_PATH_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p, attr=0x%x)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle, attr);
     return EFI_STATUS_UNSUPPORTED;
   } else if (guid_eq(protocol, EFI_BLOCK_IO_PROTOCOL_GUID)) {
-    printf("%s(EFI_BLOCK_IO_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p, attr=0x%x)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle, attr);
     return open_block_device(handle, intf);
   } else if (guid_eq(protocol, EFI_BLOCK_IO2_PROTOCOL_GUID)) {
-    printf("%s(EFI_BLOCK_IO2_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p, attr=0x%x)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle, attr);
     return open_async_block_device(handle, intf);
   } else if (guid_eq(protocol, EFI_DT_FIXUP_PROTOCOL_GUID)) {
-    printf("%s(EFI_DT_FIXUP_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p, attr=0x%x)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle, attr);
     if (intf != nullptr) {
       EfiDtFixupProtocol *fixup = nullptr;
       allocate_pool(EFI_MEMORY_TYPE_BOOT_SERVICES_DATA, sizeof(EfiDtFixupProtocol),
@@ -283,10 +348,6 @@ EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, const void **
     }
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID)) {
-    printf("%s(EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID, handle=%p, "
-           "agent_handle=%p, "
-           "controller_handle=%p, attr=0x%x)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle, attr);
     GblEfiOsConfigurationProtocol *config = nullptr;
     allocate_pool(EFI_MEMORY_TYPE_BOOT_SERVICES_DATA, sizeof(*config),
                   reinterpret_cast<void **>(&config));
@@ -300,15 +361,8 @@ EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, const void **
     *intf = reinterpret_cast<void *>(config);
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_GBL_EFI_IMAGE_LOADING_PROTOCOL_GUID)) {
-    printf(
-        "%s(EFI_GBL_EFI_IMAGE_LOADING_PROTOCOL_GUID, handle=%p, "
-        "agent_handle%p, controller_handle=%p, attr=0x%x)\n",
-        __FUNCTION__, handle, agent_handle, controller_handle, attr);
     return EFI_STATUS_UNSUPPORTED;
   } else if (guid_eq(protocol, EFI_TIMESTAMP_PROTOCOL_GUID)) {
-    printf("%s(EFI_TIMESTAMP_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p, attr=0x%x)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle, attr);
     EfiTimestampProtocol *ts = reinterpret_cast<EfiTimestampProtocol *>(
         uefi_malloc(sizeof(EfiTimestampProtocol)));
     if (ts == nullptr) {
@@ -319,81 +373,51 @@ EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, const void **
     *intf = reinterpret_cast<void *>(ts);
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_ERASE_BLOCK_PROTOCOL_GUID)) {
-    printf("%s(EFI_ERASE_BLOCK_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p, attr=0x%x)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle, attr);
     return open_efi_erase_block_protocol(handle, intf);
   } else if (guid_eq(protocol, EFI_BOOT_MEMORY_PROTOCOL_GUID)) {
-    printf(
-        "%s(EFI_BOOT_MEMORY_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-        "controller_handle=%p, attr=0x%x)\n",
-        __FUNCTION__, handle, agent_handle, controller_handle, attr);
     *intf = open_boot_memory_protocol();
     if (*intf == nullptr) {
       return EFI_STATUS_OUT_OF_RESOURCES;
     }
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_GBL_EFI_AVB_PROTOCOL_GUID)) {
-    printf(
-        "%s(EFI_GBL_EFI_AVB_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-        "controller_handle=%p, attr=0x%x)\n",
-        __FUNCTION__, handle, agent_handle, controller_handle, attr);
     *intf = open_gbl_efi_avb_protocol();
     if (*intf == nullptr) {
       return EFI_STATUS_OUT_OF_RESOURCES;
     }
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID)) {
-    printf(
-        "%s(EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-        "controller_handle=%p, attr=0x%x)\n",
-        __FUNCTION__, handle, agent_handle, controller_handle, attr);
     *intf = open_gbl_efi_boot_control_protocol();
     if (*intf == nullptr) {
       return EFI_STATUS_OUT_OF_RESOURCES;
     }
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_RNG_PROTOCOL_GUID)) {
-    printf(
-        "%s(EFI_RNG_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-        "controller_handle=%p, attr=0x%x)\n",
-        __FUNCTION__, handle, agent_handle, controller_handle, attr);
     *intf = open_efi_rng_protocol();
     if (*intf == nullptr) {
       return EFI_STATUS_OUT_OF_RESOURCES;
     }
     return EFI_STATUS_SUCCESS;
   }
-  printf("%s is unsupported 0x%x 0x%x 0x%x 0x%llx\n", __FUNCTION__,
-         protocol->data1, protocol->data2, protocol->data3,
-         *(uint64_t *)&protocol->data4);
   return EFI_STATUS_UNSUPPORTED;
 }
 
 EfiStatus close_protocol(EfiHandle handle, const EfiGuid *protocol,
                          EfiHandle agent_handle, EfiHandle controller_handle) {
+  char name_buf[64];
+  printf("%s(%s, handle=%p, agent_handle=%p, controller_handle=%p)\n",
+         __FUNCTION__, fmt_guid(protocol, name_buf, sizeof(name_buf)), handle,
+         agent_handle, controller_handle);
+
   if (guid_eq(protocol, LOADED_IMAGE_PROTOCOL_GUID)) {
-    printf("%s(LOADED_IMAGE_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle);
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_DEVICE_PATH_PROTOCOL_GUID)) {
-    printf("%s(EFI_DEVICE_PATH_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle);
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_BLOCK_IO_PROTOCOL_GUID)) {
-    printf("%s(EFI_BLOCK_IO_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle);
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_DT_FIXUP_PROTOCOL_GUID)) {
-    printf("%s(EFI_DT_FIXUP_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
-           "controller_handle=%p)\n",
-           __FUNCTION__, handle, agent_handle, controller_handle);
     return EFI_STATUS_SUCCESS;
   }
-  printf("%s is called\n", __FUNCTION__);
   return EFI_STATUS_UNSUPPORTED;
 }
 

--- a/lib/uefi/boot_service_provider.cpp
+++ b/lib/uefi/boot_service_provider.cpp
@@ -39,6 +39,14 @@
 
 namespace {
 
+EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, const void **intf,
+                        EfiHandle agent_handle, EfiHandle controller_handle,
+                        EfiOpenProtocolAttributes attr);
+
+EfiStatus locate_handle_buffer(EfiLocateHandleSearchType search_type,
+                               const EfiGuid *protocol, const void *search_key,
+                               size_t *num_handles, EfiHandle **buf);
+
 EfiStatus unload(EfiHandle handle) { return EFI_STATUS_SUCCESS; }
 
 bool guid_eq(const EfiGuid *a, const EfiGuid *b) {
@@ -47,6 +55,25 @@ bool guid_eq(const EfiGuid *a, const EfiGuid *b) {
 
 bool guid_eq(const EfiGuid *a, const EfiGuid &b) {
   return memcmp(a, &b, sizeof(*a)) == 0;
+}
+
+EfiHandle singleton_protocol_handle(const EfiGuid *protocol) {
+  if (guid_eq(protocol, EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID)) {
+    return &EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID;
+  } else if (guid_eq(protocol, EFI_DT_FIXUP_PROTOCOL_GUID)) {
+    return &EFI_DT_FIXUP_PROTOCOL_GUID;
+  } else if (guid_eq(protocol, EFI_TIMESTAMP_PROTOCOL_GUID)) {
+    return &EFI_TIMESTAMP_PROTOCOL_GUID;
+  } else if (guid_eq(protocol, EFI_BOOT_MEMORY_PROTOCOL_GUID)) {
+    return &EFI_BOOT_MEMORY_PROTOCOL_GUID;
+  } else if (guid_eq(protocol, EFI_GBL_EFI_AVB_PROTOCOL_GUID)) {
+    return &EFI_GBL_EFI_AVB_PROTOCOL_GUID;
+  } else if (guid_eq(protocol, EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID)) {
+    return &EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID;
+  } else if (guid_eq(protocol, EFI_RNG_PROTOCOL_GUID)) {
+    return &EFI_RNG_PROTOCOL_GUID;
+  }
+  return nullptr;
 }
 
 EfiStatus handle_protocol(EfiHandle handle, const EfiGuid *protocol,
@@ -88,16 +115,62 @@ EfiStatus register_protocol_notify(const EfiGuid *protocol, EfiEvent event,
 EfiStatus locate_handle(EfiLocateHandleSearchType search_type,
                         const EfiGuid *protocol, const void *search_key,
                         size_t *buf_size, EfiHandle *buf) {
+  if (buf_size == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
 
-  printf("%s is unsupported\n", __FUNCTION__);
-  return EFI_STATUS_UNSUPPORTED;
+  if (guid_eq(protocol, EFI_BLOCK_IO_PROTOCOL_GUID)) {
+    if (search_type == EFI_LOCATE_HANDLE_SEARCH_TYPE_BY_PROTOCOL) {
+      size_t num_handles = *buf_size / sizeof(EfiHandle);
+      const EfiStatus status = list_block_devices(&num_handles, buf);
+      *buf_size = num_handles * sizeof(EfiHandle);
+      return status;
+    }
+    printf("%s(0x%x, EFI_BLOCK_IO_PROTOCOL_GUID, search_key=%p)\n",
+           __FUNCTION__, search_type, search_key);
+    return EFI_STATUS_UNSUPPORTED;
+  } else if (guid_eq(protocol, EFI_TEXT_INPUT_PROTOCOL_GUID)) {
+    printf("%s(0x%x, EFI_TEXT_INPUT_PROTOCOL_GUID, search_key=%p)\n",
+           __FUNCTION__, search_type, search_key);
+    return EFI_STATUS_NOT_FOUND;
+  }
+
+  const EfiHandle singleton_handle = singleton_protocol_handle(protocol);
+  if (singleton_handle != nullptr) {
+    printf("%s(0x%x, %p, search_key=%p)\n", __FUNCTION__, search_type, protocol,
+           search_key);
+
+    const size_t required_size = sizeof(EfiHandle);
+    if (*buf_size < required_size) {
+      *buf_size = required_size;
+      return EFI_STATUS_BUFFER_TOO_SMALL;
+    }
+
+    *buf_size = required_size;
+    if (buf != nullptr) {
+      *buf = singleton_handle;
+    }
+    return EFI_STATUS_SUCCESS;
+  }
+
+  printf("%s(0x%x, (0x%x 0x%x 0x%x 0x%llx), search_key=%p)\n", __FUNCTION__,
+         search_type, protocol->data1, protocol->data2, protocol->data3,
+         *(uint64_t *)&protocol->data4, search_key);
+  return EFI_STATUS_NOT_FOUND;
 }
 
 EfiStatus locate_protocol(const EfiGuid *protocol, void *registration,
                           void **intf) {
-  if (protocol == nullptr) {
+  if (protocol == nullptr || intf == nullptr) {
     return EFI_STATUS_INVALID_PARAMETER;
   }
+
+  const EfiHandle singleton_handle = singleton_protocol_handle(protocol);
+  if (singleton_handle != nullptr) {
+    return open_protocol(singleton_handle, protocol, const_cast<const void **>(intf),
+                         nullptr, nullptr, 0);
+  }
+
   if (memcmp(protocol, &EFI_RNG_PROTOCOL_GUID, sizeof(*protocol)) == 0) {
     printf("%s(EFI_RNG_PROTOCOL_GUID) is unsupported.\n", __FUNCTION__);
     return EFI_STATUS_UNSUPPORTED;
@@ -110,7 +183,7 @@ EfiStatus locate_protocol(const EfiGuid *protocol, void *registration,
   printf("%s(%x %x %x %llx) is unsupported\n", __FUNCTION__, protocol->data1,
          protocol->data2, protocol->data3,
          *reinterpret_cast<const uint64_t *>(&protocol->data4));
-  return EFI_STATUS_UNSUPPORTED;
+  return EFI_STATUS_NOT_FOUND;
 }
 
 EfiStatus uninstall_multiple_protocol_interfaces(EfiHandle handle, ...) {
@@ -260,6 +333,36 @@ EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, const void **
       return EFI_STATUS_OUT_OF_RESOURCES;
     }
     return EFI_STATUS_SUCCESS;
+  } else if (guid_eq(protocol, EFI_GBL_EFI_AVB_PROTOCOL_GUID)) {
+    printf(
+        "%s(EFI_GBL_EFI_AVB_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
+        "controller_handle=%p, attr=0x%x)\n",
+        __FUNCTION__, handle, agent_handle, controller_handle, attr);
+    *intf = open_gbl_efi_avb_protocol();
+    if (*intf == nullptr) {
+      return EFI_STATUS_OUT_OF_RESOURCES;
+    }
+    return EFI_STATUS_SUCCESS;
+  } else if (guid_eq(protocol, EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID)) {
+    printf(
+        "%s(EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
+        "controller_handle=%p, attr=0x%x)\n",
+        __FUNCTION__, handle, agent_handle, controller_handle, attr);
+    *intf = open_gbl_efi_boot_control_protocol();
+    if (*intf == nullptr) {
+      return EFI_STATUS_OUT_OF_RESOURCES;
+    }
+    return EFI_STATUS_SUCCESS;
+  } else if (guid_eq(protocol, EFI_RNG_PROTOCOL_GUID)) {
+    printf(
+        "%s(EFI_RNG_PROTOCOL_GUID, handle=%p, agent_handle=%p, "
+        "controller_handle=%p, attr=0x%x)\n",
+        __FUNCTION__, handle, agent_handle, controller_handle, attr);
+    *intf = open_efi_rng_protocol();
+    if (*intf == nullptr) {
+      return EFI_STATUS_OUT_OF_RESOURCES;
+    }
+    return EFI_STATUS_SUCCESS;
   }
   printf("%s is unsupported 0x%x 0x%x 0x%x 0x%llx\n", __FUNCTION__,
          protocol->data1, protocol->data2, protocol->data3,
@@ -297,62 +400,40 @@ EfiStatus close_protocol(EfiHandle handle, const EfiGuid *protocol,
 EfiStatus locate_handle_buffer(EfiLocateHandleSearchType search_type,
                                const EfiGuid *protocol, const void *search_key,
                                size_t *num_handles, EfiHandle **buf) {
-  if (guid_eq(protocol, EFI_BLOCK_IO_PROTOCOL_GUID)) {
-    if (search_type == EFI_LOCATE_HANDLE_SEARCH_TYPE_BY_PROTOCOL) {
-      return list_block_devices(num_handles, buf);
-    }
-    printf("%s(0x%x, EFI_BLOCK_IO_PROTOCOL_GUID, search_key=%p)\n",
-           __FUNCTION__, search_type, search_key);
-    return EFI_STATUS_UNSUPPORTED;
-  } else if (guid_eq(protocol, EFI_TEXT_INPUT_PROTOCOL_GUID)) {
-    printf("%s(0x%x, EFI_TEXT_INPUT_PROTOCOL_GUID, search_key=%p)\n",
-           __FUNCTION__, search_type, search_key);
-    return EFI_STATUS_NOT_FOUND;
-  } else if (guid_eq(protocol, EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID)) {
-    printf("%s(0x%x, EFI_GBL_OS_CONFIGURATION_PROTOCOL_GUID, search_key=%p)\n",
-           __FUNCTION__, search_type, search_key);
-    if (num_handles != nullptr) {
-      *num_handles = 1;
-    }
-    if (buf != nullptr) {
-      *buf = reinterpret_cast<EfiHandle *>(uefi_malloc(sizeof(buf)));
-    }
-    return EFI_STATUS_SUCCESS;
-  } else if (guid_eq(protocol, EFI_DT_FIXUP_PROTOCOL_GUID)) {
-    printf("%s(0x%x, EFI_DT_FIXUP_PROTOCOL_GUID, search_key=%p)\n",
-           __FUNCTION__, search_type, search_key);
-    if (num_handles != nullptr) {
-      *num_handles = 1;
-    }
-    if (buf != nullptr) {
-      *buf = reinterpret_cast<EfiHandle *>(uefi_malloc(sizeof(buf)));
-    }
-    return EFI_STATUS_SUCCESS;
-  } else if (guid_eq(protocol, EFI_TIMESTAMP_PROTOCOL_GUID)) {
-    printf("%s(0x%x, EFI_TIMESTAMP_PROTOCOL_GUID, search_key=%p)\n",
-           __FUNCTION__, search_type, search_key);
-    if (num_handles != nullptr) {
-      *num_handles = 1;
-    }
-    if (buf != nullptr) {
-      *buf = reinterpret_cast<EfiHandle *>(uefi_malloc(sizeof(buf)));
-    }
-    return EFI_STATUS_SUCCESS;
-  } else if (guid_eq(protocol, EFI_BOOT_MEMORY_PROTOCOL_GUID)) {
-    printf("%s(0x%x, EFI_BOOT_MEMORY_PROTOCOL_GUID, search_key=%p)\n",
-           __FUNCTION__, search_type, search_key);
-    if (num_handles != nullptr) {
-      *num_handles = 1;
-    }
-    if (buf != nullptr) {
-      *buf = reinterpret_cast<EfiHandle*>(uefi_malloc(sizeof(buf)));
-    }
-    return EFI_STATUS_SUCCESS;
+  if (num_handles == nullptr || buf == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
   }
-  printf("%s(0x%x, (0x%x 0x%x 0x%x 0x%llx), search_key=%p)\n", __FUNCTION__,
-         search_type, protocol->data1, protocol->data2, protocol->data3,
-         *(uint64_t *)&protocol->data4, search_key);
-  return EFI_STATUS_UNSUPPORTED;
+  *num_handles = 0;
+  *buf = nullptr;
+
+  size_t buf_size = 0;
+  EfiStatus status =
+      locate_handle(search_type, protocol, search_key, &buf_size, nullptr);
+  if (status != EFI_STATUS_BUFFER_TOO_SMALL) {
+    return status;
+  }
+
+  status = allocate_pool(EFI_MEMORY_TYPE_BOOT_SERVICES_DATA, buf_size,
+                         reinterpret_cast<void **>(buf));
+  if (status != EFI_STATUS_SUCCESS) {
+    return status;
+  }
+
+  status = locate_handle(search_type, protocol, search_key, &buf_size, *buf);
+  if (status != EFI_STATUS_SUCCESS) {
+    free_pool(*buf);
+    *buf = nullptr;
+    return status;
+  }
+
+  *num_handles = buf_size / sizeof(EfiHandle);
+  if (*num_handles == 0) {
+    free_pool(*buf);
+    *buf = nullptr;
+    return EFI_STATUS_NOT_FOUND;
+  }
+
+  return EFI_STATUS_SUCCESS;
 }
 
 EfiStatus stall(size_t microseconds) {

--- a/lib/uefi/boot_service_provider.h
+++ b/lib/uefi/boot_service_provider.h
@@ -98,6 +98,12 @@ static constexpr auto EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID =
             0x11f0,
             {0x84, 0xc7, 0x04, 0x7b, 0xcb, 0xa9, 0x60, 0x19}};
 
+static constexpr auto EFI_GBL_EFI_AVB_PROTOCOL_GUID =
+    EfiGuid{0x6bc66b9a,
+            0xd5c9,
+            0x4c02,
+            {0x9d, 0xa9, 0x50, 0xaf, 0x19, 0x8d, 0x91, 0x2c}};
+
 static constexpr auto EFI_GBL_EFI_FASTBOOT_PROTOCOL_GUID =
     EfiGuid{0xc67e48a0,
             0x5eb8,

--- a/lib/uefi/memory_protocols.cpp
+++ b/lib/uefi/memory_protocols.cpp
@@ -286,6 +286,27 @@ EfiStatus get_boot_buffer(struct GblEfiBootMemoryProtocol* self,
       return EFI_STATUS_OUT_OF_RESOURCES;
     }
     return EFI_STATUS_SUCCESS;
+  } else if (buf_type == GBL_EFI_BOOT_BUFFER_TYPE_KERNEL) {
+    *size = 64ul * 1024 * 1024;
+    *addr = alloc_page(*size, 21);
+    if (*addr == nullptr) {
+      return EFI_STATUS_OUT_OF_RESOURCES;
+    }
+    return EFI_STATUS_SUCCESS;
+  } else if (buf_type == GBL_EFI_BOOT_BUFFER_TYPE_RAMDISK) {
+    *size = 64ul * 1024 * 1024;
+    *addr = alloc_page(*size, PAGE_SIZE_SHIFT);
+    if (*addr == nullptr) {
+      return EFI_STATUS_OUT_OF_RESOURCES;
+    }
+    return EFI_STATUS_SUCCESS;
+  } else if (buf_type == GBL_EFI_BOOT_BUFFER_TYPE_FDT) {
+    *size = 2ul * 1024 * 1024;
+    *addr = alloc_page(*size, PAGE_SIZE_SHIFT);
+    if (*addr == nullptr) {
+      return EFI_STATUS_OUT_OF_RESOURCES;
+    }
+    return EFI_STATUS_SUCCESS;
   } else if (buf_type == GBL_EFI_BOOT_BUFFER_TYPE_PVMFW_DATA) {
     *size = 1024ul * 1024;
     *addr = alloc_page(*size, PAGE_SIZE_SHIFT);

--- a/lib/uefi/uefi_platform.cpp
+++ b/lib/uefi/uefi_platform.cpp
@@ -28,6 +28,9 @@
 #include <uefi/protocols/erase_block_protocol.h>
 #include <uefi/protocols/gbl_efi_image_loading_protocol.h>
 #include <uefi/protocols/gbl_efi_os_configuration_protocol.h>
+#include <uefi/protocols/gbl_efi_avb_protocol.h>
+#include <uefi/protocols/gbl_efi_boot_control_protocol.h>
+#include <uefi/protocols/random_number_generator_protocol.h>
 #include <uefi/types.h>
 
 #include "defer.h"
@@ -88,13 +91,43 @@ __WEAK EfiStatus fixup_bootconfig(struct GblEfiOsConfigurationProtocol* self,
   return EFI_STATUS_SUCCESS;
 }
 
+namespace {
+
+bool select_first_dtb(size_t num_device_trees,
+                      GblEfiVerifiedDeviceTree* device_trees,
+                      GblEfiDeviceTreeType type) {
+  for (size_t i = 0; i < num_device_trees; i++) {
+    if (device_trees[i].metadata.type == type) {
+      device_trees[i].selected = true;
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
 // Selects which device trees and overlays to use from those loaded by GBL.
 __WEAK EfiStatus select_device_trees(struct GblEfiOsConfigurationProtocol* self,
                                      size_t num_device_trees,
                                      GblEfiVerifiedDeviceTree* device_trees) {
   printf("%s(%p, %p %lu)\n", __FUNCTION__, self, device_trees,
          num_device_trees);
-  return EFI_STATUS_UNSUPPORTED;
+  if (num_device_trees > 0) {
+    if (device_trees == nullptr) {
+      return EFI_STATUS_INVALID_PARAMETER;
+    }
+    for (size_t i = 0; i < num_device_trees; i++) {
+      device_trees[i].selected = false;
+    }
+    if (!select_first_dtb(num_device_trees, device_trees,
+                          GBL_EFI_DEVICE_TREE_TYPE_DEVICE_TREE)) {
+      return EFI_STATUS_UNSUPPORTED;
+    }
+    select_first_dtb(num_device_trees, device_trees,
+                     GBL_EFI_DEVICE_TREE_TYPE_OVERLAY);
+  }
+  return EFI_STATUS_SUCCESS;
 }
 
 __WEAK EfiStatus select_fit_configuration(
@@ -202,6 +235,137 @@ EfiStatus erase_blocks(EfiEraseBlockProtocol* self, uint32_t media_id,
   return EFI_STATUS_SUCCESS;
 }
 
+EfiStatus avb_read_partition_attributes(
+    struct GblEfiAvbProtocol* self,
+    /* in-out */ size_t* num_partitions,
+    /* in-out */ GblEfiAvbPartitionAttributes* partitions) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus avb_read_device_status(
+    struct GblEfiAvbProtocol* self,
+    /* out */ GblEfiAvbDeviceStatus* status_flags) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus avb_validate_vbmeta_public_key(
+    struct GblEfiAvbProtocol* self,
+    /* in */ size_t public_key_length,
+    /* in */ const uint8_t* public_key_data,
+    /* in */ size_t public_key_metadata_length,
+    /* in */ const uint8_t* public_key_metadata,
+    /* out */ GblEfiAvbKeyValidationStatus* validation_status) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus avb_read_rollback_index(struct GblEfiAvbProtocol* self,
+                                  /* in */ size_t index_location,
+                                  /* out */ uint64_t* rollback_index) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus avb_write_rollback_index(struct GblEfiAvbProtocol* self,
+                                   /* in */ size_t index_location,
+                                   /* in */ uint64_t rollback_index) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus avb_read_persistent_value(struct GblEfiAvbProtocol* self,
+                                    /* in */ const EfiChar8* name,
+                                    /* in-out */ size_t* value_size,
+                                    /* out */ uint8_t* value) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus avb_write_persistent_value(struct GblEfiAvbProtocol* self,
+                                     /* in */ const EfiChar8* name,
+                                     /* in */ size_t value_size,
+                                     /* in */ const uint8_t* value) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus avb_handle_verification_result(
+    struct GblEfiAvbProtocol* self,
+    /* in */ const GblEfiAvbVerificationResult* result) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus avb_write_lock_state(struct GblEfiAvbProtocol* self,
+                               /* in */ GblEfiAvbLockType type,
+                               /* in */ GblEfiAvbLockState state) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus avb_factory_data_reset(struct GblEfiAvbProtocol* self) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus boot_control_get_slot_count(struct GblEfiBootControlProtocol* self,
+                                      uint8_t* slot_count) {
+  if (slot_count == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+  *slot_count = 1;
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus boot_control_get_slot_info(struct GblEfiBootControlProtocol* self,
+                                     uint8_t index, GblEfiSlotInfo* info) {
+  if (info == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+  if (index > 0) {
+    return EFI_STATUS_NOT_FOUND;
+  }
+  info->suffix = 'a';
+  info->unbootable_reason = GBL_EFI_UNBOOTABLE_REASON_UNKNOWN_REASON;
+  info->priority = 15;
+  info->remaining_tries = 7;
+  info->successful = 1;
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus boot_control_get_current_slot(struct GblEfiBootControlProtocol* self,
+                                        GblEfiSlotInfo* info) {
+  return boot_control_get_slot_info(self, 0, info);
+}
+
+EfiStatus boot_control_set_active_slot(struct GblEfiBootControlProtocol* self,
+                                       uint8_t index) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus boot_control_get_one_shot_boot_mode(
+    struct GblEfiBootControlProtocol* self, GblEfiOneShotBootMode* mode) {
+  if (mode == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+  *mode = GBL_EFI_ONE_SHOT_BOOT_MODE_NONE;
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus boot_control_handle_loaded_os(struct GblEfiBootControlProtocol* self,
+                                        const GblEfiLoadedOs* os) {
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus rng_get_info(EfiRngProtocol* self, size_t* rng_algorithm_list_size,
+                       EfiRngAlgorithm* rng_algorithm_list) {
+  if (rng_algorithm_list_size == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+  *rng_algorithm_list_size = 0;
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus rng_get_rng(EfiRngProtocol* self, const EfiRngAlgorithm* rng_algorithm,
+                      size_t rng_value_length, uint8_t* rng_value) {
+  if (rng_value == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+  return EFI_STATUS_UNSUPPORTED;
+}
+
 }  // namespace
 
 __WEAK EfiStatus open_efi_erase_block_protocol(EfiHandle handle, const void** intf) {
@@ -221,4 +385,42 @@ __WEAK EfiStatus open_efi_erase_block_protocol(EfiHandle handle, const void** in
   };
   *intf = p;
   return EFI_STATUS_SUCCESS;
+}
+
+__WEAK GblEfiAvbProtocol* open_gbl_efi_avb_protocol() {
+  static GblEfiAvbProtocol protocol = {
+      .revision = GBL_EFI_AVB_PROTOCOL_REVISION,
+      .read_partition_attributes = avb_read_partition_attributes,
+      .read_device_status = avb_read_device_status,
+      .validate_vbmeta_public_key = avb_validate_vbmeta_public_key,
+      .read_rollback_index = avb_read_rollback_index,
+      .write_rollback_index = avb_write_rollback_index,
+      .read_persistent_value = avb_read_persistent_value,
+      .write_persistent_value = avb_write_persistent_value,
+      .handle_verification_result = avb_handle_verification_result,
+      .write_lock_state = avb_write_lock_state,
+      .factory_data_reset = avb_factory_data_reset,
+  };
+  return &protocol;
+}
+
+__WEAK GblEfiBootControlProtocol* open_gbl_efi_boot_control_protocol() {
+  static GblEfiBootControlProtocol protocol = {
+      .revision = GBL_EFI_BOOT_CONTROL_PROTOCOL_REVISION,
+      .get_slot_count = boot_control_get_slot_count,
+      .get_slot_info = boot_control_get_slot_info,
+      .get_current_slot = boot_control_get_current_slot,
+      .set_active_slot = boot_control_set_active_slot,
+      .get_one_shot_boot_mode = boot_control_get_one_shot_boot_mode,
+      .handle_loaded_os = boot_control_handle_loaded_os,
+  };
+  return &protocol;
+}
+
+__WEAK EfiRngProtocol* open_efi_rng_protocol() {
+  static EfiRngProtocol protocol = {
+      .get_info = rng_get_info,
+      .get_rng = rng_get_rng,
+  };
+  return &protocol;
 }

--- a/lib/uefi/uefi_platform.h
+++ b/lib/uefi/uefi_platform.h
@@ -19,9 +19,12 @@
 #define __GBL_OS_CONFIGURATION_
 
 #include <arch/defines.h>
+#include <uefi/protocols/gbl_efi_avb_protocol.h>
+#include <uefi/protocols/gbl_efi_boot_control_protocol.h>
 #include <uefi/protocols/gbl_efi_boot_memory_protocol.h>
 #include <uefi/protocols/gbl_efi_image_loading_protocol.h>
 #include <uefi/protocols/gbl_efi_os_configuration_protocol.h>
+#include <uefi/protocols/random_number_generator_protocol.h>
 #include <uefi/protocols/timestamp.h>
 #include <uefi/system_table.h>
 #include <uefi/types.h>
@@ -84,5 +87,11 @@ void reset_heap();
 EfiStatus open_efi_erase_block_protocol(EfiHandle handle, const void** intf);
 
 GblEfiBootMemoryProtocol* open_boot_memory_protocol();
+
+GblEfiAvbProtocol* open_gbl_efi_avb_protocol();
+
+GblEfiBootControlProtocol* open_gbl_efi_boot_control_protocol();
+
+EfiRngProtocol* open_efi_rng_protocol();
 
 #endif


### PR DESCRIPTION
## Summary

- add UEFI protocol implementations needed by GBL
- add boot buffer allocation support for UEFI boot flows
- print readable protocol GUID names in UEFI boot service traces

## Test

- `source .env && make qemu-virt-arm64-test`
- `git diff --check origin/master..HEAD`
