### PR TITLE
[ci] update apt index before clang install

### DIFF
--- a/.github/workflows/github-ci-clang.yml
+++ b/.github/workflows/github-ci-clang.yml
@@ -52,6 +52,7 @@ jobs:
     - name: compute toolchain
       shell: bash
       run: |
+        env -i DEBIAN_FRONTEND=noninteractive sudo apt-get update
         sudo apt-get install -y clang-${{ matrix.toolchain-ver }} lld-${{ matrix.toolchain-ver }}
         GCC_TOOLCHAIN_PREFIX=$(make list-toolchain | grep TOOLCHAIN_PREFIX | tail -1 | cut -d ' ' -f 3)
         # Map the GCC toolchain prefix to a clang --target argument:
@@ -80,7 +81,6 @@ jobs:
       if: ${{ matrix.project == 'qemu-virt-arm64-test' }}
       shell: bash
       run: |
-        env -i DEBIAN_FRONTEND=noninteractive sudo apt-get update
         env -i DEBIAN_FRONTEND=noninteractive sudo apt-get install -y qemu-system-arm expect
     - name: uefi unittest
       if: ${{ matrix.project == 'qemu-virt-arm64-test' }}

--- a/.github/workflows/github-ci-rust.yml
+++ b/.github/workflows/github-ci-rust.yml
@@ -48,6 +48,7 @@ jobs:
     - name: compute toolchain
       shell: bash
       run: |
+        env -i DEBIAN_FRONTEND=noninteractive sudo apt-get update
         sudo apt-get install -y clang-${{ matrix.toolchain-ver }} lld-${{ matrix.toolchain-ver }}
         GCC_TOOLCHAIN_PREFIX=$(make list-toolchain | grep TOOLCHAIN_PREFIX | tail -1 | cut -d ' ' -f 3)
         # Map the GCC toolchain prefix to a clang --target argument:
@@ -76,7 +77,6 @@ jobs:
       if: ${{ matrix.project == 'qemu-virt-arm64-test' }}
       shell: bash
       run: |
-        env -i DEBIAN_FRONTEND=noninteractive sudo apt-get update
         env -i DEBIAN_FRONTEND=noninteractive sudo apt-get install -y qemu-system-arm expect
     - name: uefi unittest
       if: ${{ matrix.project == 'qemu-virt-arm64-test' }}


### PR DESCRIPTION
## Summary

- run `apt-get update` before installing clang/lld in the Clang CI workflow
- apply the same setup fix to the Rust workflow, which installs clang/lld the same way

## Motivation

Several clang-20 jobs recently failed before reaching the build step because the runner's apt package index pointed at stale package versions that returned 404 from Ubuntu mirrors. Refreshing the package index before installing clang/lld makes this setup step less flaky on GitHub-hosted runners.

## Test

- `git diff --check`
