### PR TITLE
[app][inetsrv] use correct buffer size in tcp_read

### DIFF
--- a/app/inetsrv/inetsrv.c
+++ b/app/inetsrv/inetsrv.c
@@ -153,7 +153,7 @@ static int echo_worker(void *socket) {
     }
 
     for (;;) {
-        ssize_t ret = tcp_read(s, buf, sizeof(buf));
+        ssize_t ret = tcp_read(s, buf, ECHO_BUFSIZE);
         if (ret <= 0)
             break;
 


### PR DESCRIPTION
## Summary

Fix the buffer size argument passed to `tcp_read()` in `app/inetsrv/inetsrv.c`.

The previous code used `sizeof(buf)`, which evaluates to the size of the
pointer rather than the intended buffer capacity. Use `ECHO_BUFSIZE` instead.

## Testing

- `make qemu-virt-arm64-test`