### PR TITLE
[lib][console] Remove redundant NULL checks before free

### DIFF
--- a/lib/console/console.c
+++ b/lib/console/console.c
@@ -714,11 +714,8 @@ static status_t command_loop(console_t *con, int (*get_line)(const char **, void
     return NO_ERROR;
 
 no_mem_error:
-    if (outbuf)
-        free(outbuf);
-
-    if (args)
-        free(args);
+    free(outbuf);
+    free(args);
 
     dprintf(INFO, "%s: not enough memory\n", __func__);
     return ERR_NO_MEMORY;


### PR DESCRIPTION
## Summary

Remove redundant `NULL` checks before `free()` in `lib/console/console.c`.

In the `no_mem_error` path of `command_loop()`, `free(outbuf)` and `free(args)` are sufficient because `free(NULL)` is defined as a no-op in C. This simplifies the cleanup path without changing behavior.

## Testing

-`make qemu-virt-arm64-test` 