### PR TITLE
Fix reading 32-bit start_cluster instead of only reading 16-bit.

### DIFF
--- a/lib/fs/fat/dir.cpp
+++ b/lib/fs/fat/dir.cpp
@@ -480,7 +480,11 @@ status_t fat_find_next_entry(fat_fs *fat, file_block_iterator &dbi, uint32_t &of
             LTRACEF("found filename '%s'\n", *out_filename);
 
             // fill out the passed in dir entry and exit
-            uint16_t target_cluster = fat_read16(ent, 0x1a);
+            uint32_t target_cluster = fat_read16(ent, 0x1a);
+            if (fat->info().fat_bits == 32) {
+                target_cluster |= (uint32_t)fat_read16(ent, 0x14) << 16;
+                target_cluster &= 0x0fffffff;
+            }
             entry->length = fat_read32(ent, 0x1c);
             entry->attributes = (fat_attribute)ent[0x0B];
             entry->start_cluster = target_cluster;
@@ -658,7 +662,11 @@ status_t fat_find_short_file_in_dir_with_offsets(fat_fs *fat, uint32_t starting_
             }
 
             if (!memcmp(ent, short_name, 11)) {
-                uint16_t target_cluster = fat_read16(ent, 0x1a);
+                uint32_t target_cluster = fat_read16(ent, 0x1a);
+                if (fat->info().fat_bits == 32) {
+                    target_cluster |= (uint32_t)fat_read16(ent, 0x14) << 16;
+                    target_cluster &= 0x0fffffff;
+                }
                 entry->length = fat_read32(ent, 0x1c);
                 entry->attributes = (fat_attribute)ent[0x0B];
                 entry->start_cluster = target_cluster;


### PR DESCRIPTION
For FAT32, the First Cluster Number is stored in the Directory Entry's DIR_FstClusHI (0x14) and DIR_FstClusLO (0x1a). However, target_cluster currently reads only the lower 16 bits, which will cause issues on FAT32 systems when files are not located in low clusters.