### PR TITLE
 [arch][m68k] Fix typo in MMU page table validation functions

### DIFF
--- a/arch/m68k/mmu.c
+++ b/arch/m68k/mmu.c
@@ -359,13 +359,13 @@ static void dump_mmu_regs(void) {
 static bool is_l0_entry_valid(root_ptp_t entry) {
     // 0, 1 == invalid
     // 2, 3 == valid
-    return entry.udt > 2;
+    return entry.udt >= 2;
 }
 
 static bool is_l1_entry_valid(ptp_t entry) {
     // 0, 1 == invalid
     // 2, 3 == valid
-    return entry.udt > 2;
+    return entry.udt >= 2;
 }
 
 static bool is_l2_entry_valid(pte_t entry) {


### PR DESCRIPTION
Root and pointer page table entry (L0, L1) validation functions currently check for greater-than 2 against the UDT descriptor. Shouldn't this be >= 2, or similar?

From the 68040 manual:

"UDT—Upper Level Descriptor Type
These bits indicate whether the next level table descriptor is resident. 

00 or 01 = Invalid
These codes indicate that the table at the next level is not resident or that the logical address is out of bounds. All other bits in the descriptor are ignored. When an invalid descriptor is encountered, an ATC entry is created for the logical address with the resident bit in the MMUSR clear. 

10 or 11 = Resident
These codes indicate that the page is resident"