### PR TITLE
[lib][uefi] implement UEFI HII Database Protocol

### DIFF
--- a/lib/uefi/boot_service_provider.cpp
+++ b/lib/uefi/boot_service_provider.cpp
@@ -28,6 +28,7 @@
 #include <uefi/protocols/dt_fixup_protocol.h>
 #include <uefi/protocols/gbl_efi_image_loading_protocol.h>
 #include <uefi/protocols/gbl_efi_os_configuration_protocol.h>
+#include <uefi/protocols/hii_protocol.h>
 #include <uefi/protocols/loaded_image_protocol.h>
 #include <uefi/types.h>
 
@@ -86,6 +87,7 @@ const char *protocol_name(const EfiGuid *protocol) {
       {&EFI_TIMESTAMP_PROTOCOL_GUID, "EFI_TIMESTAMP_PROTOCOL_GUID"},
       {&EFI_BOOT_MEMORY_PROTOCOL_GUID, "EFI_BOOT_MEMORY_PROTOCOL_GUID"},
       {&EFI_ERASE_BLOCK_PROTOCOL_GUID, "EFI_ERASE_BLOCK_PROTOCOL_GUID"},
+      {&EFI_HII_DATABASE_PROTOCOL_GUID, "EFI_HII_DATABASE_PROTOCOL_GUID"},
   };
 
   for (const auto &entry : kProtocolGuidNames) {
@@ -136,6 +138,7 @@ EfiHandle singleton_protocol_handle(const EfiGuid *protocol) {
       &EFI_GBL_EFI_AVB_PROTOCOL_GUID,
       &EFI_GBL_EFI_BOOT_CONTROL_PROTOCOL_GUID,
       &EFI_RNG_PROTOCOL_GUID,
+      &EFI_HII_DATABASE_PROTOCOL_GUID,
   };
 
   for (const EfiGuid *singleton_guid : kSingletonGuids) {
@@ -398,6 +401,12 @@ EfiStatus open_protocol(EfiHandle handle, const EfiGuid *protocol, const void **
       return EFI_STATUS_OUT_OF_RESOURCES;
     }
     return EFI_STATUS_SUCCESS;
+  } else if (guid_eq(protocol, EFI_HII_DATABASE_PROTOCOL_GUID)) {
+    *intf = open_hii_database_protocol();
+    if (*intf == nullptr) {
+      return EFI_STATUS_OUT_OF_RESOURCES;
+    }
+    return EFI_STATUS_SUCCESS;
   }
   return EFI_STATUS_UNSUPPORTED;
 }
@@ -416,6 +425,8 @@ EfiStatus close_protocol(EfiHandle handle, const EfiGuid *protocol,
   } else if (guid_eq(protocol, EFI_BLOCK_IO_PROTOCOL_GUID)) {
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_DT_FIXUP_PROTOCOL_GUID)) {
+    return EFI_STATUS_SUCCESS;
+  } else if (guid_eq(protocol, EFI_HII_DATABASE_PROTOCOL_GUID)) {
     return EFI_STATUS_SUCCESS;
   }
   return EFI_STATUS_UNSUPPORTED;

--- a/lib/uefi/boot_service_provider.h
+++ b/lib/uefi/boot_service_provider.h
@@ -140,6 +140,12 @@ static constexpr auto EFI_ERASE_BLOCK_PROTOCOL_GUID =
             0x4926,
             {0xaa, 0xef, 0x99, 0x18, 0xe7, 0x72, 0xd9, 0x87}};
 
+static constexpr auto EFI_HII_DATABASE_PROTOCOL_GUID =
+    EfiGuid{0xef9fc172,
+            0xa1b2,
+            0x4693,
+            {0xb3, 0x27, 0x6d, 0x32, 0xfc, 0x41, 0x60, 0x42}};
+
 // This function would be called from GBL before jumping into android kernel
 // LK provides a default no-op implementation that is weakly linked,
 // different platforms can override with their own implementation.

--- a/lib/uefi/hii_protocol.cpp
+++ b/lib/uefi/hii_protocol.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <lk/list.h>
+#include <malloc.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <uefi/protocols/hii_protocol.h>
+
+namespace {
+
+constexpr uint32_t kPackageTypeShift = 24;
+constexpr uint32_t kPackageTypeMask = 0xff;
+constexpr uint32_t kPackageLengthMask = 0xffffff;
+
+struct EfiHiiPackageList {
+  list_node node;
+  EfiHandle driver_handle;
+  EfiGuid package_list_guid{};
+};
+
+list_node package_lists = LIST_INITIAL_VALUE(package_lists);
+
+uint32_t package_type(const EfiHiiPackageHeader *header) {
+  const uint32_t fields = header->fields;
+  return (fields >> kPackageTypeShift) & kPackageTypeMask;
+}
+
+uint32_t package_length(const EfiHiiPackageHeader *header) {
+  const uint32_t fields = header->fields;
+  return fields & kPackageLengthMask;
+}
+
+bool package_list_is_valid(const EfiHiiPackageListHeader *package_list) {
+  if (package_list->package_length <
+      sizeof(*package_list) + sizeof(EfiHiiPackageHeader)) {
+    return false;
+  }
+
+  const auto *package = reinterpret_cast<const EfiHiiPackageHeader *>(
+      reinterpret_cast<const uint8_t *>(package_list) + sizeof(*package_list));
+  size_t remaining = package_list->package_length - sizeof(*package_list);
+
+  while (remaining >= sizeof(*package)) {
+    const uint32_t length = package_length(package);
+    if (length < sizeof(*package) || length > remaining) {
+      return false;
+    }
+
+    if (package_type(package) == EFI_HII_PACKAGE_END) {
+      return length == sizeof(*package) && length == remaining;
+    }
+
+    remaining -= length;
+    package = reinterpret_cast<const EfiHiiPackageHeader *>(
+        reinterpret_cast<const uint8_t *>(package) + length);
+  }
+
+  return false;
+}
+
+bool guid_equal(const EfiGuid &left, const EfiGuid &right) {
+  return memcmp(&left, &right, sizeof(left)) == 0;
+}
+
+EfiHiiPackageList *find_package_list(EfiHiiHandle handle) {
+  EfiHiiPackageList *package_list = nullptr;
+  list_for_every_entry(&package_lists, package_list, EfiHiiPackageList, node) {
+    if (package_list == handle) {
+      return package_list;
+    }
+  }
+  return nullptr;
+}
+
+bool package_list_guid_exists(const EfiGuid &guid, EfiHandle driver_handle) {
+  EfiHiiPackageList *package_list = nullptr;
+  list_for_every_entry(&package_lists, package_list, EfiHiiPackageList, node) {
+    if (package_list->driver_handle == driver_handle &&
+        guid_equal(package_list->package_list_guid, guid)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+EfiStatus new_package_list(const EfiHiiDatabaseProtocol *self,
+                           const EfiHiiPackageListHeader *package_list,
+                           EfiHandle driver_handle, EfiHiiHandle *handle) {
+  if (self == nullptr || package_list == nullptr || handle == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+  *handle = nullptr;
+
+  if (!package_list_is_valid(package_list)) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+
+  EfiGuid package_list_guid;
+  memcpy(&package_list_guid, &package_list->package_list_guid,
+         sizeof(package_list_guid));
+  if (package_list_guid_exists(package_list_guid, driver_handle)) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+
+  auto *hii =
+      reinterpret_cast<EfiHiiPackageList *>(malloc(sizeof(EfiHiiPackageList)));
+  if (hii == nullptr) {
+    return EFI_STATUS_OUT_OF_RESOURCES;
+  }
+
+  *hii = {};
+  hii->node = LIST_INITIAL_CLEARED_VALUE;
+  hii->driver_handle = driver_handle;
+  hii->package_list_guid = package_list_guid;
+  list_add_tail(&package_lists, &hii->node);
+  *handle = hii;
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus remove_package_list(const EfiHiiDatabaseProtocol *self,
+                              EfiHiiHandle handle) {
+  if (self == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+
+  EfiHiiPackageList *package_list = find_package_list(handle);
+  if (package_list == nullptr) {
+    return EFI_STATUS_NOT_FOUND;
+  }
+
+  list_delete(&package_list->node);
+  free(package_list);
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus update_package_list(const EfiHiiDatabaseProtocol *self,
+                              EfiHiiHandle handle,
+                              const EfiHiiPackageListHeader *package_list) {
+  printf("UEFI: Hii: update_package_list is not supported\n");
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus list_package_lists(const EfiHiiDatabaseProtocol *self,
+                             uint8_t package_type, const EfiGuid *package_guid,
+                             size_t *buffer_size, EfiHiiHandle *handle) {
+  printf("UEFI: Hii: list_package_lists is not supported\n");
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus export_package_lists(const EfiHiiDatabaseProtocol *self,
+                               EfiHiiHandle handle, size_t *buffer_size,
+                               EfiHiiPackageListHeader *buffer) {
+  printf("UEFI: Hii: export_package_lists is not supported\n");
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus register_package_notify(const EfiHiiDatabaseProtocol *self,
+                                  uint8_t package_type,
+                                  const EfiGuid *package_guid,
+                                  EfiHiiDatabaseNotify package_notify_fn,
+                                  EfiHiiDatabaseNotifyType notify_type,
+                                  EfiHandle *notify_handle) {
+  printf("UEFI: Hii: register_package_notify is not supported\n");
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus unregister_package_notify(const EfiHiiDatabaseProtocol *self,
+                                    EfiHandle notification_handle) {
+  printf("UEFI: Hii: unregister_package_notify is not supported\n");
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus find_keyboard_layouts(const EfiHiiDatabaseProtocol *self,
+                                uint16_t *key_guid_buffer_length,
+                                EfiGuid *key_guid_buffer) {
+  printf("UEFI: Hii: find_keyboard_layouts is not supported\n");
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus get_keyboard_layout(const EfiHiiDatabaseProtocol *self,
+                              EfiGuid *key_guid,
+                              uint16_t *keyboard_layout_length,
+                              EfiHiiKeyboardLayout *keyboard_layout) {
+  printf("UEFI: Hii: get_keyboard_layout is not supported\n");
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus set_keyboard_layout(const EfiHiiDatabaseProtocol *self,
+                              EfiGuid *key_guid) {
+  printf("UEFI: Hii: set_keyboard_layout is not supported\n");
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus get_package_list_handle(const EfiHiiDatabaseProtocol *self,
+                                  EfiHiiHandle handle,
+                                  EfiHandle *driver_handle) {
+  if (self == nullptr || driver_handle == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+
+  EfiHiiPackageList *package_list = find_package_list(handle);
+  if (package_list == nullptr) {
+    return EFI_STATUS_NOT_FOUND;
+  }
+
+  *driver_handle = package_list->driver_handle;
+  return EFI_STATUS_SUCCESS;
+}
+
+}  // namespace
+
+__WEAK EfiHiiDatabaseProtocol *open_hii_database_protocol() {
+  static EfiHiiDatabaseProtocol protocol = {
+      .new_package_list = new_package_list,
+      .remove_package_list = remove_package_list,
+      .update_package_list = update_package_list,
+      .list_package_lists = list_package_lists,
+      .export_package_lists = export_package_lists,
+      .register_package_notify = register_package_notify,
+      .unregister_package_notify = unregister_package_notify,
+      .find_keyboard_layouts = find_keyboard_layouts,
+      .get_keyboard_layout = get_keyboard_layout,
+      .set_keyboard_layout = set_keyboard_layout,
+      .get_package_list_handle = get_package_list_handle,
+  };
+  return &protocol;
+}

--- a/lib/uefi/include/uefi/protocols/hii_protocol.h
+++ b/lib/uefi/include/uefi/protocols/hii_protocol.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR BSD-2-Clause-Patent
+ *
+ * You may choose to use or redistribute this file under
+ *  (a) the Apache License, Version 2.0, or
+ *  (b) the BSD 2-Clause Patent license.
+ *
+ * Unless you expressly elect the BSD-2-Clause-Patent terms, the Apache-2.0
+ * terms apply by default.
+ */
+
+#pragma once
+
+#include <lk/compiler.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <uefi/types.h>
+
+#define EFI_HII_PACKAGE_TYPE_ALL 0x00
+#define EFI_HII_PACKAGE_TYPE_GUID 0x01
+#define EFI_HII_PACKAGE_FORMS 0x02
+#define EFI_HII_PACKAGE_STRINGS 0x04
+#define EFI_HII_PACKAGE_FONTS 0x05
+#define EFI_HII_PACKAGE_IMAGES 0x06
+#define EFI_HII_PACKAGE_SIMPLE_FONTS 0x07
+#define EFI_HII_PACKAGE_DEVICE_PATH 0x08
+#define EFI_HII_PACKAGE_KEYBOARD_LAYOUT 0x09
+#define EFI_HII_PACKAGE_ANIMATIONS 0x0a
+#define EFI_HII_PACKAGE_END 0xdf
+#define EFI_HII_PACKAGE_TYPE_SYSTEM_BEGIN 0xe0
+#define EFI_HII_PACKAGE_TYPE_SYSTEM_END 0xff
+
+typedef void *EfiHiiHandle;
+typedef size_t EfiHiiDatabaseNotifyType;
+
+typedef struct EfiHiiPackageListHeader {
+  EfiGuid package_list_guid;
+  uint32_t package_length;
+} __PACKED EfiHiiPackageListHeader;
+
+typedef struct EfiHiiPackageHeader {
+  uint32_t fields;
+} __PACKED EfiHiiPackageHeader;
+
+typedef struct EfiHiiKeyboardLayout {
+  uint16_t layout_length;
+  EfiGuid guid;
+  uint32_t layout_descriptor_string_offset;
+  uint8_t descriptor_count;
+} __PACKED EfiHiiKeyboardLayout;
+
+typedef EfiStatus (*EfiHiiDatabaseNotify)(uint8_t package_type,
+                                          const EfiGuid *package_guid,
+                                          const EfiHiiPackageHeader *package,
+                                          EfiHiiHandle handle,
+                                          EfiHiiDatabaseNotifyType notify_type);
+
+typedef struct EfiHiiDatabaseProtocol EfiHiiDatabaseProtocol;
+
+struct EfiHiiDatabaseProtocol {
+  EfiStatus (*new_package_list)(const EfiHiiDatabaseProtocol *self,
+                                const EfiHiiPackageListHeader *package_list,
+                                EfiHandle driver_handle, EfiHiiHandle *handle);
+  EfiStatus (*remove_package_list)(const EfiHiiDatabaseProtocol *self,
+                                   EfiHiiHandle handle);
+  EfiStatus (*update_package_list)(const EfiHiiDatabaseProtocol *self,
+                                   EfiHiiHandle handle,
+                                   const EfiHiiPackageListHeader *package_list);
+  EfiStatus (*list_package_lists)(const EfiHiiDatabaseProtocol *self,
+                                  uint8_t package_type,
+                                  const EfiGuid *package_guid,
+                                  size_t *buffer_size, EfiHiiHandle *handle);
+  EfiStatus (*export_package_lists)(const EfiHiiDatabaseProtocol *self,
+                                    EfiHiiHandle handle, size_t *buffer_size,
+                                    EfiHiiPackageListHeader *buffer);
+  EfiStatus (*register_package_notify)(const EfiHiiDatabaseProtocol *self,
+                                       uint8_t package_type,
+                                       const EfiGuid *package_guid,
+                                       EfiHiiDatabaseNotify package_notify_fn,
+                                       EfiHiiDatabaseNotifyType notify_type,
+                                       EfiHandle *notify_handle);
+  EfiStatus (*unregister_package_notify)(const EfiHiiDatabaseProtocol *self,
+                                         EfiHandle notification_handle);
+  EfiStatus (*find_keyboard_layouts)(const EfiHiiDatabaseProtocol *self,
+                                     uint16_t *key_guid_buffer_length,
+                                     EfiGuid *key_guid_buffer);
+  EfiStatus (*get_keyboard_layout)(const EfiHiiDatabaseProtocol *self,
+                                   EfiGuid *key_guid,
+                                   uint16_t *keyboard_layout_length,
+                                   EfiHiiKeyboardLayout *keyboard_layout);
+  EfiStatus (*set_keyboard_layout)(const EfiHiiDatabaseProtocol *self,
+                                   EfiGuid *key_guid);
+  EfiStatus (*get_package_list_handle)(const EfiHiiDatabaseProtocol *self,
+                                       EfiHiiHandle package_list_handle,
+                                       EfiHandle *driver_handle);
+};

--- a/lib/uefi/rules.mk
+++ b/lib/uefi/rules.mk
@@ -13,6 +13,8 @@ MODULE_DEPS += \
 	lib/heap/dlmalloc \
 	lib/libcpp \
 
+MODULE_OPTIONS := test
+
 MODULE_SRCS += \
 	$(LOCAL_DIR)/uefi.cpp \
 	$(LOCAL_DIR)/relocation.cpp \
@@ -30,6 +32,7 @@ MODULE_SRCS += \
 	$(LOCAL_DIR)/debug_support.cpp \
 	$(LOCAL_DIR)/charset.cpp \
 	$(LOCAL_DIR)/variable_mem.cpp \
+	$(LOCAL_DIR)/hii_protocol.cpp \
 
 
 include make/module.mk

--- a/lib/uefi/test/hii_protocol_tests.cpp
+++ b/lib/uefi/test/hii_protocol_tests.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <lib/unittest.h>
+#include <stdint.h>
+#include <uefi/protocols/hii_protocol.h>
+
+#include "../uefi_platform.h"
+
+namespace {
+
+constexpr uint32_t package_fields(uint8_t type, uint32_t length) {
+  return (static_cast<uint32_t>(type) << 24) | length;
+}
+
+struct EndOnlyPackageList {
+  EfiHiiPackageListHeader header;
+  EfiHiiPackageHeader end;
+} __PACKED;
+
+EndOnlyPackageList make_package_list(uint32_t guid_data1) {
+  return {
+      .header =
+          {
+              .package_list_guid =
+                  {
+                      .data1 = guid_data1,
+                      .data2 = 0x1234,
+                      .data3 = 0x5678,
+                      .data4 = {0x90, 0xab, 0xcd, 0xef, 1, 2, 3, 4},
+                  },
+              .package_length = sizeof(EndOnlyPackageList),
+          },
+      .end = {.fields = package_fields(EFI_HII_PACKAGE_END,
+                                       sizeof(EfiHiiPackageHeader))},
+  };
+}
+
+bool hii_package_list_lifecycle_test() {
+  BEGIN_TEST;
+
+  EfiHiiDatabaseProtocol *protocol = open_hii_database_protocol();
+  ASSERT_NONNULL(protocol);
+
+  EndOnlyPackageList package_list = make_package_list(1);
+  int first_driver = 0;
+  int second_driver = 0;
+  EfiHiiHandle first_handle = nullptr;
+  EfiHiiHandle second_handle = nullptr;
+
+  EXPECT_EQ(EFI_STATUS_SUCCESS,
+            protocol->new_package_list(protocol, &package_list.header,
+                                       &first_driver, &first_handle));
+  ASSERT_NONNULL(first_handle);
+
+  EfiHandle driver_handle = nullptr;
+  EXPECT_EQ(EFI_STATUS_SUCCESS, protocol->get_package_list_handle(
+                                    protocol, first_handle, &driver_handle));
+  EXPECT_EQ(static_cast<EfiHandle>(&first_driver), driver_handle);
+
+  EXPECT_EQ(EFI_STATUS_INVALID_PARAMETER,
+            protocol->new_package_list(protocol, &package_list.header,
+                                       &first_driver, &second_handle));
+  EXPECT_NULL(second_handle);
+
+  EXPECT_EQ(EFI_STATUS_SUCCESS,
+            protocol->new_package_list(protocol, &package_list.header,
+                                       &second_driver, &second_handle));
+  ASSERT_NONNULL(second_handle);
+
+  EXPECT_EQ(EFI_STATUS_SUCCESS,
+            protocol->remove_package_list(protocol, first_handle));
+  EXPECT_EQ(EFI_STATUS_NOT_FOUND,
+            protocol->remove_package_list(protocol, first_handle));
+  EXPECT_EQ(EFI_STATUS_SUCCESS,
+            protocol->remove_package_list(protocol, second_handle));
+
+  END_TEST;
+}
+
+bool hii_package_list_validation_test() {
+  BEGIN_TEST;
+
+  EfiHiiDatabaseProtocol *protocol = open_hii_database_protocol();
+  ASSERT_NONNULL(protocol);
+
+  EndOnlyPackageList package_list = make_package_list(2);
+  EfiHiiHandle handle = nullptr;
+
+  EXPECT_EQ(EFI_STATUS_INVALID_PARAMETER,
+            protocol->new_package_list(nullptr, &package_list.header, nullptr,
+                                       &handle));
+  EXPECT_EQ(EFI_STATUS_INVALID_PARAMETER,
+            protocol->new_package_list(protocol, nullptr, nullptr, &handle));
+  EXPECT_EQ(EFI_STATUS_INVALID_PARAMETER,
+            protocol->new_package_list(protocol, &package_list.header, nullptr,
+                                       nullptr));
+
+  package_list.header.package_length = sizeof(EfiHiiPackageListHeader);
+  EXPECT_EQ(EFI_STATUS_INVALID_PARAMETER,
+            protocol->new_package_list(protocol, &package_list.header, nullptr,
+                                       &handle));
+
+  package_list = make_package_list(2);
+  package_list.end.fields = package_fields(EFI_HII_PACKAGE_FORMS, 0);
+  EXPECT_EQ(EFI_STATUS_INVALID_PARAMETER,
+            protocol->new_package_list(protocol, &package_list.header, nullptr,
+                                       &handle));
+
+  package_list = make_package_list(2);
+  package_list.end.fields =
+      package_fields(EFI_HII_PACKAGE_FORMS, sizeof(EfiHiiPackageHeader));
+  EXPECT_EQ(EFI_STATUS_INVALID_PARAMETER,
+            protocol->new_package_list(protocol, &package_list.header, nullptr,
+                                       &handle));
+
+  package_list = make_package_list(2);
+  package_list.end.fields =
+      package_fields(EFI_HII_PACKAGE_END, sizeof(EfiHiiPackageHeader) + 1);
+  EXPECT_EQ(EFI_STATUS_INVALID_PARAMETER,
+            protocol->new_package_list(protocol, &package_list.header, nullptr,
+                                       &handle));
+
+  END_TEST;
+}
+
+BEGIN_TEST_CASE(hii_protocol_tests);
+RUN_TEST(hii_package_list_lifecycle_test);
+RUN_TEST(hii_package_list_validation_test);
+END_TEST_CASE(hii_protocol_tests);
+
+}  // namespace

--- a/lib/uefi/test/rules.mk
+++ b/lib/uefi/test/rules.mk
@@ -1,0 +1,13 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+
+MODULE := $(LOCAL_DIR)
+
+MODULE_DEFINES := GBL_EFI_DISABLE_CPP_ENUMS=1
+
+MODULE_SRCS += $(LOCAL_DIR)/hii_protocol_tests.cpp
+
+MODULE_DEPS += \
+	lib/uefi \
+	lib/unittest \
+
+include make/module.mk

--- a/lib/uefi/uefi_platform.h
+++ b/lib/uefi/uefi_platform.h
@@ -24,6 +24,7 @@
 #include <uefi/protocols/gbl_efi_boot_memory_protocol.h>
 #include <uefi/protocols/gbl_efi_image_loading_protocol.h>
 #include <uefi/protocols/gbl_efi_os_configuration_protocol.h>
+#include <uefi/protocols/hii_protocol.h>
 #include <uefi/protocols/random_number_generator_protocol.h>
 #include <uefi/protocols/timestamp.h>
 #include <uefi/system_table.h>
@@ -93,5 +94,7 @@ GblEfiAvbProtocol* open_gbl_efi_avb_protocol();
 GblEfiBootControlProtocol* open_gbl_efi_boot_control_protocol();
 
 EfiRngProtocol* open_efi_rng_protocol();
+
+EfiHiiDatabaseProtocol *open_hii_database_protocol();
 
 #endif


### PR DESCRIPTION
Supersedes #478, rebased onto current master and updated to address its review feedback.

Shell.efi from EDK2 requires this protocol to exist; otherwise it crashes. This implements the minimum UEFI HII Database Protocol functionality needed by Shell.efi.

Original implementation and commit author: @grandpaul (Ying-Chun Liu / PaulLiu).

Changes in this revision:
- Integrate HII Database with the current singleton-protocol lifecycle.
- Implement NewPackageList(), RemovePackageList(), and GetPackageListHandle().
- Validate package framing and reject duplicate package-list GUIDs for one driver.
- Add lifecycle and malformed-input unit tests.

Validation:
- ARM64 Clang+LLD debug and release builds passed.
- QEMU ARM64 unit tests passed: 32/32 cases.
- UEFI hello-world application loaded and ran successfully.