### PR TITLE
[lib][uefi] fix FreePages on identity-mapped pages and per-run teardown leaks

### DIFF
--- a/lib/uefi/configuration_table.cpp
+++ b/lib/uefi/configuration_table.cpp
@@ -28,7 +28,8 @@
 void setup_configuration_table(EfiSystemTable *system_table, EfiConfigurationTable *configuration_table) {
   auto& rng = configuration_table[system_table->number_of_table_entries++];
   rng.vendor_guid = LINUX_EFI_RANDOM_SEED_TABLE_GUID;
-  auto rng_seed = reinterpret_cast<linux_efi_random_seed*>(alloc_page(PAGE_SIZE));
+  auto rng_seed = reinterpret_cast<linux_efi_random_seed*>(
+      uefi_malloc(sizeof(linux_efi_random_seed) + 512));
   rng.vendor_table = rng_seed;
   rng_seed->size = 512;
   memset(&rng_seed->bits, 0, rng_seed->size);
@@ -38,7 +39,7 @@ void setup_configuration_table(EfiSystemTable *system_table, EfiConfigurationTab
     auto& dtb = configuration_table[system_table->number_of_table_entries++];
     dtb.vendor_guid = DEVICE_TREE_GUID;
     const auto fdt_size = fdt_totalsize(fdt);
-    auto vendor_table = alloc_page(fdt_size);
+    auto vendor_table = uefi_malloc(fdt_size);
     dtb.vendor_table = vendor_table;
     memcpy(vendor_table, fdt, fdt_size);
   }

--- a/lib/uefi/debug_support.cpp
+++ b/lib/uefi/debug_support.cpp
@@ -75,6 +75,13 @@ EfiStatus efi_initialize_system_table_pointer(struct EfiSystemTable *system_tabl
   return EFI_STATUS_SUCCESS;
 }
 
+void efi_uninitialize_system_table_pointer() {
+  if (efi_systab_pointer != nullptr) {
+    free_pages(efi_systab_pointer, 1);
+    efi_systab_pointer = nullptr;
+  }
+}
+
 static uint32_t efi_m_max_table_entries;
 
 static constexpr size_t EFI_DEBUG_TABLE_ENTRY_SIZE = (sizeof(union EfiDebugImageInfo));

--- a/lib/uefi/debug_support.cpp
+++ b/lib/uefi/debug_support.cpp
@@ -258,6 +258,12 @@ void teardown_debug_support(char *image_base) {
       free_pool(device_buf);
       free_pool(efiLoadedImageProtocol);
 
+      if (efi_m_debug_info_table_header.table_size == 0) {
+        free_pool(efi_m_debug_info_table_header.efi_debug_image_info_table);
+        efi_m_debug_info_table_header = {};
+        efi_m_max_table_entries = 0;
+      }
+
       return;
     }
   }

--- a/lib/uefi/debug_support.h
+++ b/lib/uefi/debug_support.h
@@ -58,6 +58,7 @@ struct EfiDebugImageInfoTableHeader {
 };
 
 EfiStatus efi_initialize_system_table_pointer(struct EfiSystemTable *system_table);
+void efi_uninitialize_system_table_pointer();
 EfiStatus efi_core_new_debug_image_info_entry(uint32_t image_info_type,
                                               EfiLoadedImageProtocol *loaded_image,
                                               EfiHandle image_handle);

--- a/lib/uefi/memory_protocols.cpp
+++ b/lib/uefi/memory_protocols.cpp
@@ -197,11 +197,19 @@ __WEAK EfiStatus free_pool(void *mem) {
 }
 
 __WEAK EfiStatus free_pages(void *memory, size_t pages) {
-  auto pa = reinterpret_cast<void *>(vaddr_to_paddr(memory));
-  if (pa != memory) {
+  auto pa = vaddr_to_paddr(memory);
+  if (pa != reinterpret_cast<paddr_t>(memory)) {
     printf("WARN: virtual address %p is not identity mapped, physical addr: "
            "%p\n",
-           memory, pa);
+           memory, reinterpret_cast<void *>(pa));
+  }
+  // pmm_free_kpages expects a kernel virtual address. Keep the permanent
+  // kernel mapping before removing the UEFI identity mapping below.
+  auto kernel_memory = paddr_to_kvaddr(pa);
+  if (kernel_memory == nullptr) {
+    printf("Failed to find kernel mapping for physical pages %p %zu\n",
+           reinterpret_cast<void *>(pa), pages);
+    return EFI_STATUS_DEVICE_ERROR;
   }
   status_t err =
       vmm_free_region(set_boot_aspace(), reinterpret_cast<vaddr_t>(memory));
@@ -210,10 +218,10 @@ __WEAK EfiStatus free_pages(void *memory, size_t pages) {
            pages);
     return EFI_STATUS_DEVICE_ERROR;
   }
-  auto pages_freed = pmm_free_kpages(pa, pages);
+  auto pages_freed = pmm_free_kpages(kernel_memory, pages);
   if (pages_freed != pages) {
-    printf("Failed to free physical pages %p %zu, only freed %zu pages\n", pa,
-           pages, pages_freed);
+    printf("Failed to free physical pages %p %zu, only freed %zu pages\n",
+           reinterpret_cast<void *>(pa), pages, pages_freed);
     return EFI_STATUS_DEVICE_ERROR;
   }
   return EFI_STATUS_SUCCESS;

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -207,6 +207,7 @@ int load_sections_and_execute(ImageReader *reader,
     printf("efi_initialize_system_table_pointer failed: %lu\n", status);
     return -static_cast<int>(status);
   }
+  DEFER { efi_uninitialize_system_table_pointer(); };
   char path[FS_MAX_PATH_LEN];
   reader->get_name(path, sizeof(path));
   path[sizeof(path) - 1] = '\0';


### PR DESCRIPTION
Running a UEFI application currently leaks all of its page allocations plus several per-run structures, and a second `uefi_load` in the same session can crash.

Root cause of the page leak: `free_pages()` removed the UEFI identity mapping first, then passed the raw physical address to `pmm_free_kpages()`, which expects a kernel virtual address. The lookup failed, `FreePages` returned `EFI_STATUS_DEVICE_ERROR`, and the pages never went back to the PMM. On qemu-virt-arm64 a single hello-world run leaked ~302 MiB (77327 pages), including the 300 MiB per-run UEFI heap.

Fixes in this series:

* **fix freeing identity-mapped pages**: resolve the permanent kernel VA via `paddr_to_kvaddr()` before removing the UEFI identity mapping, then free through `pmm_free_kpages()`
* **allocate configuration table buffers from the UEFI pool**: the RNG seed and the FDT copy now come from `uefi_malloc()`, so `reset_heap()` reclaims them wholesale after every run and no teardown pass has to act on sizes or pointers living in app-writable memory
* **release the system table pointer**: free the `EfiSystemTablePointer` allocation after the app returns
* **release the empty debug image table**: free the table backing storage and reset the published header when the last image is removed, so a later `uefi_load` cannot dereference state pointing into the previous run's destroyed heap

Validation (qemu-virt-arm64-test, Clang/LLD, WERROR=1):

* Custom AllocatePages/FreePages EFI test app: allocate -> write -> free -> re-allocate passes, freed pages are reused, and PMM `free_count` is identical before/after two consecutive runs
* Stock `helloworld_aa64.efi` runs twice in one session with no leak (PMM `free_count` identical before/after) and no crash (the second run previously faulted)
* `ut all`: 36/36 pass
