### PR TITLE
[lib][uefi] fix a heap overflow, uninitialized con_out, and stale event list links

### DIFF
--- a/lib/uefi/debug_support.cpp
+++ b/lib/uefi/debug_support.cpp
@@ -132,7 +132,7 @@ EfiStatus efi_core_new_debug_image_info_entry(uint32_t image_info_type,
 
   /* Allocate data for new entry. */
   allocate_pool(EFI_MEMORY_TYPE_BOOT_SERVICES_DATA,
-		      sizeof(union EfiDebugImageInfo),
+		      sizeof(struct EfiDebugImageInfoNormal),
 		      reinterpret_cast<void **>(&table[index].normal_image));
   if (table[index].normal_image) {
     /* Update the entry. */

--- a/lib/uefi/events.cpp
+++ b/lib/uefi/events.cpp
@@ -73,7 +73,8 @@ void process_pending_events() {
     }
   }
   al.release();
-  list_for_every_entry(&completed_events, ev, EfiEventImpl, node) {
+  while ((ev = list_remove_head_type(&completed_events, EfiEventImpl, node)) !=
+         nullptr) {
     invoke_callback(ev);
   }
 }

--- a/lib/uefi/events.cpp
+++ b/lib/uefi/events.cpp
@@ -103,6 +103,10 @@ EfiStatus wait_for_event(size_t num_events, EfiEvent *event, size_t *index) {
       if (status == ERR_TIMED_OUT) {
         continue;
       }
+      if (status != NO_ERROR) {
+        return EFI_STATUS_DEVICE_ERROR;
+      }
+      *index = i;
       return EFI_STATUS_SUCCESS;
     }
   }

--- a/lib/uefi/text_protocol.cpp
+++ b/lib/uefi/text_protocol.cpp
@@ -35,8 +35,82 @@ EfiStatus output_string(struct EfiSimpleTextOutputProtocol *self,
   return EFI_STATUS_SUCCESS;
 }
 
+namespace {
+
+EfiStatus reset(struct EfiSimpleTextOutputProtocol *self,
+                bool extended_verification) {
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus test_string(struct EfiSimpleTextOutputProtocol *self,
+                      uint16_t *string) {
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus query_mode(struct EfiSimpleTextOutputProtocol *self, size_t mode_num,
+                     size_t *cols, size_t *rows) {
+  if (mode_num != 0) {
+    return EFI_STATUS_UNSUPPORTED;
+  }
+  if (cols != nullptr) {
+    *cols = 80;
+  }
+  if (rows != nullptr) {
+    *rows = 25;
+  }
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus set_mode(struct EfiSimpleTextOutputProtocol *self, size_t mode_num) {
+  if (mode_num != 0) {
+    return EFI_STATUS_UNSUPPORTED;
+  }
+  return EFI_STATUS_SUCCESS;
+}
+
+// EFI default: light gray text on a black background.
+SimpleTextOutputMode console_out_mode = {
+    .max_mode = 1,
+    .mode = 0,
+    .attribute = 0x07,
+    .cursor_column = 0,
+    .cursor_row = 0,
+    .cursor_visible = false,
+};
+
+EfiStatus set_attribute(struct EfiSimpleTextOutputProtocol *self,
+                        size_t attribute) {
+  console_out_mode.attribute = static_cast<int32_t>(attribute);
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus clear_screen(struct EfiSimpleTextOutputProtocol *self) {
+  return EFI_STATUS_SUCCESS;
+}
+
+EfiStatus set_cursor_position(struct EfiSimpleTextOutputProtocol *self,
+                              size_t col, size_t row) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+EfiStatus enable_cursor(struct EfiSimpleTextOutputProtocol *self,
+                        bool visible) {
+  return EFI_STATUS_UNSUPPORTED;
+}
+
+}  // namespace
+
 EfiSimpleTextOutputProtocol get_text_output_protocol() {
-  EfiSimpleTextOutputProtocol console_out;
+  EfiSimpleTextOutputProtocol console_out = {};
+  console_out.reset = reset;
   console_out.output_string = output_string;
+  console_out.test_string = test_string;
+  console_out.query_mode = query_mode;
+  console_out.set_mode = set_mode;
+  console_out.set_attribute = set_attribute;
+  console_out.clear_screen = clear_screen;
+  console_out.set_cursor_position = set_cursor_position;
+  console_out.enable_cursor = enable_cursor;
+  console_out.mode = &console_out_mode;
   return console_out;
 }


### PR DESCRIPTION
Four independent memory-safety fixes in lib/uefi, found while auditing the loader:

* **allocate the right size for debug image info entries**: `efi_core_new_debug_image_info_entry()` allocated `sizeof(union EfiDebugImageInfo)` (8 bytes, a single pointer) for the `normal_image` entry and then wrote a 24-byte `struct EfiDebugImageInfoNormal` through it, a 16-byte pool overflow on every image load.

* **fully initialize the simple text output protocol**: `get_text_output_protocol()` returned a struct with every member except `output_string` uninitialized. An application calling `reset`, `clear_screen`, or `query_mode`, or dereferencing `mode`, jumped through stack garbage. All callbacks now have benign implementations and `mode` points at a static 80x25 description.

* **unlink completed events before invoking callbacks**: `process_pending_events()` moved ready events onto a stack-local list and left the nodes chained there after returning. A later `close_event`/`check_event` passed `delete_if_in_list`'s non-null check and wrote through pointers into the dead stack frame. Events are now popped off the local list (which clears their links) before their callbacks run.

* **set the output index when wait_for_event succeeds**: the `event_wait_timeout` success path returned without storing which event finished the wait, so callers read an uninitialized index.

Validation (qemu-virt-arm64-test, Clang/LLD, WERROR=1):

* `helloworld_aa64.efi` loads and runs (return code 0), `ut all` passes 36/36, no faults in the log
* The event-list and wait_for_event paths are exercised by async block IO (EFI_BLOCK_IO2), which GBL uses to load images
* Also validated with #530 applied on top: two consecutive `uefi_load` runs both succeed with PMM `free_count` identical before/after, `ut all` 36/36

The series is based on current master and is independent of #530; the two touch different hunks and apply cleanly in either order.
