### PR TITLE
[lib][uefi] correctness, resource lifetime, and PE parsing fixes

### DIFF
--- a/lib/uefi/blockio2_protocols.cpp
+++ b/lib/uefi/blockio2_protocols.cpp
@@ -27,6 +27,7 @@
 #include <uefi/protocols/block_io2_protocol.h>
 #include <uefi/types.h>
 
+#include "blockio_protocols.h"
 #include "events.h"
 #include "io_stack.h"
 #include "memory_protocols.h"
@@ -134,10 +135,21 @@ EfiStatus flush_blocks_ex(EfiBlockIo2Protocol* self, EfiBlockIo2Token* token) {
 }  // namespace
 
 __WEAK EfiStatus open_async_block_device(EfiHandle handle, const void** intf) {
-  auto dev = bio_open(reinterpret_cast<const char*>(handle));
+  bdev_t *dev = nullptr;
+  EfiStatus status =
+      open_tracked_bdev(reinterpret_cast<const char*>(handle), &dev);
+  if (status != EFI_STATUS_SUCCESS) {
+    if (status == EFI_STATUS_NOT_FOUND) {
+      printf("%s: no such block device\n", __FUNCTION__);
+    }
+    return status;
+  }
   printf("%s(%s)\n", __FUNCTION__, dev->name);
   auto interface = reinterpret_cast<EfiBlockIo2Interface*>(
       uefi_malloc(sizeof(EfiBlockIo2Interface)));
+  if (interface == nullptr) {
+    return EFI_STATUS_OUT_OF_RESOURCES;
+  }
   auto protocol = &interface->protocol;
   auto media = &interface->media;
   protocol->media = media;

--- a/lib/uefi/blockio_protocols.cpp
+++ b/lib/uefi/blockio_protocols.cpp
@@ -60,13 +60,13 @@ EfiStatus read_blocks(EfiBlockIoProtocol *self, uint32_t media_id, uint64_t lba,
 
 EfiStatus write_blocks(EfiBlockIoProtocol *self, uint32_t media_id,
                        uint64_t lba, size_t buffer_size, void *buffer) {
-  printf("%s is called\n", __FUNCTION__);
-  return EFI_STATUS_SUCCESS;
+  printf("Writing blocks from UEFI app is currently not supported to protect "
+         "the device.\n");
+  return EFI_STATUS_UNSUPPORTED;
 }
 
 EfiStatus flush_blocks(EfiBlockIoProtocol *self) {
-  printf("%s is called\n", __FUNCTION__);
-  return EFI_STATUS_SUCCESS;
+  return EFI_STATUS_UNSUPPORTED;
 }
 
 EfiStatus reset(EfiBlockIoProtocol *self, bool extended_verification) {

--- a/lib/uefi/blockio_protocols.cpp
+++ b/lib/uefi/blockio_protocols.cpp
@@ -18,6 +18,7 @@
 
 #include <kernel/vm.h>
 #include <lib/bio.h>
+#include <malloc.h>
 #include <string.h>
 #include <uefi/protocols/block_io_protocol.h>
 #include <uefi/types.h>
@@ -75,6 +76,48 @@ EfiStatus reset(EfiBlockIoProtocol *self, bool extended_verification) {
 }
 }  // namespace
 
+namespace {
+// Every bio_open() for the current image run is tracked so its reference can be
+// released at teardown by close_tracked_bdevs(). This is a growable list rather
+// than a fixed array on purpose: close_protocol() does not release individual
+// Block I/O references, so the tracker counts cumulative opens, and a bounded
+// table would reject opens after enough OpenProtocol/CloseProtocol cycles.
+struct TrackedBdev {
+  bdev_t *dev;
+  TrackedBdev *next;
+};
+TrackedBdev *tracked_bdevs = nullptr;
+}  // namespace
+
+EfiStatus open_tracked_bdev(const char *name, bdev_t **out_dev) {
+  *out_dev = nullptr;
+  bdev_t *dev = bio_open(name);
+  if (dev == nullptr) {
+    return EFI_STATUS_NOT_FOUND;
+  }
+  auto *node = reinterpret_cast<TrackedBdev *>(malloc(sizeof(TrackedBdev)));
+  if (node == nullptr) {
+    // Can't remember the reference, so don't hand out an untracked one.
+    printf("%s: out of memory tracking %s\n", __FUNCTION__, name);
+    bio_close(dev);
+    return EFI_STATUS_OUT_OF_RESOURCES;
+  }
+  node->dev = dev;
+  node->next = tracked_bdevs;
+  tracked_bdevs = node;
+  *out_dev = dev;
+  return EFI_STATUS_SUCCESS;
+}
+
+void close_tracked_bdevs() {
+  while (tracked_bdevs != nullptr) {
+    TrackedBdev *node = tracked_bdevs;
+    tracked_bdevs = node->next;
+    bio_close(node->dev);
+    free(node);
+  }
+}
+
 __WEAK EfiStatus open_block_device(EfiHandle handle, const void** intf) {
   printf("%s(%p)\n", __FUNCTION__, handle);
   auto io_stack = get_io_stack();
@@ -87,7 +130,15 @@ __WEAK EfiStatus open_block_device(EfiHandle handle, const void** intf) {
     return EFI_STATUS_OUT_OF_RESOURCES;
   }
   memset(interface, 0, sizeof(EfiBlockIoInterface));
-  auto dev = bio_open(reinterpret_cast<const char *>(handle));
+  bdev_t *dev = nullptr;
+  EfiStatus status =
+      open_tracked_bdev(reinterpret_cast<const char *>(handle), &dev);
+  if (status != EFI_STATUS_SUCCESS) {
+    if (status == EFI_STATUS_NOT_FOUND) {
+      printf("%s: no such block device\n", __FUNCTION__);
+    }
+    return status;
+  }
   interface->dev = dev;
   interface->protocol.revision = EFI_BLOCK_IO_PROTOCOL_REVISION;
   interface->protocol.reset = reset;

--- a/lib/uefi/blockio_protocols.cpp
+++ b/lib/uefi/blockio_protocols.cpp
@@ -109,6 +109,19 @@ EfiStatus open_tracked_bdev(const char *name, bdev_t **out_dev) {
   return EFI_STATUS_SUCCESS;
 }
 
+bool close_tracked_bdev(const char *name) {
+  for (TrackedBdev **pp = &tracked_bdevs; *pp != nullptr; pp = &(*pp)->next) {
+    if (strcmp((*pp)->dev->name, name) == 0) {
+      TrackedBdev *node = *pp;
+      *pp = node->next;
+      bio_close(node->dev);
+      free(node);
+      return true;
+    }
+  }
+  return false;
+}
+
 void close_tracked_bdevs() {
   while (tracked_bdevs != nullptr) {
     TrackedBdev *node = tracked_bdevs;

--- a/lib/uefi/blockio_protocols.h
+++ b/lib/uefi/blockio_protocols.h
@@ -1,10 +1,19 @@
 #ifndef __LIB_UEFI_BLOCKIO_PROTOCOL_H_
 #define __LIB_UEFI_BLOCKIO_PROTOCOL_H_
 
+#include <lib/bio.h>
 #include <uefi/types.h>
 
 EfiStatus open_block_device(EfiHandle handle, const void **intf);
 
 EfiStatus list_block_devices(size_t *num_handles, EfiHandle *buf);
+
+// bio_open wrapper that remembers the device so the reference can be
+// released by close_tracked_bdevs() when the current image run tears down.
+// On success *out_dev holds the opened device. Returns EFI_STATUS_NOT_FOUND
+// when the device does not exist and EFI_STATUS_OUT_OF_RESOURCES when the
+// tracking table is full (so callers can distinguish the two).
+EfiStatus open_tracked_bdev(const char *name, bdev_t **out_dev);
+void close_tracked_bdevs();
 
 #endif

--- a/lib/uefi/blockio_protocols.h
+++ b/lib/uefi/blockio_protocols.h
@@ -8,12 +8,17 @@ EfiStatus open_block_device(EfiHandle handle, const void **intf);
 
 EfiStatus list_block_devices(size_t *num_handles, EfiHandle *buf);
 
-// bio_open wrapper that remembers the device so the reference can be
-// released by close_tracked_bdevs() when the current image run tears down.
+// bio_open wrapper that remembers the device so the reference can be released
+// at teardown by close_tracked_bdevs(), or individually by close_tracked_bdev()
+// when the app calls CloseProtocol.
 // On success *out_dev holds the opened device. Returns EFI_STATUS_NOT_FOUND
-// when the device does not exist and EFI_STATUS_OUT_OF_RESOURCES when the
-// tracking table is full (so callers can distinguish the two).
+// when the device does not exist and EFI_STATUS_OUT_OF_RESOURCES when a tracking
+// node cannot be allocated (out of memory), so callers can distinguish the two.
 EfiStatus open_tracked_bdev(const char *name, bdev_t **out_dev);
+// Release a single tracked reference to the named device, balancing one open
+// (used by CloseProtocol). Returns true if a tracked open was found and closed;
+// an untracked or duplicate close is a harmless no-op.
+bool close_tracked_bdev(const char *name);
 void close_tracked_bdevs();
 
 #endif

--- a/lib/uefi/boot_service_provider.cpp
+++ b/lib/uefi/boot_service_provider.cpp
@@ -17,6 +17,7 @@
 #include "boot_service_provider.h"
 
 #include <endian.h>
+#include <limits.h>
 #include <lib/cksum.h>
 #include <lk/compiler.h>
 #include <stdio.h>
@@ -260,10 +261,22 @@ EfiStatus uninstall_multiple_protocol_interfaces(EfiHandle handle, ...) {
   return EFI_STATUS_UNSUPPORTED;
 }
 EfiStatus calculate_crc32(void *data, size_t len, uint32_t *crc_out) {
-  if (data == nullptr || crc_out == nullptr || len == 0) {
+  if (data == nullptr || crc_out == nullptr) {
     return EFI_STATUS_INVALID_PARAMETER;
   }
-  *crc_out = crc32(0, static_cast<const unsigned char *>(data), len);
+  // A non-null zero-length buffer has a well-defined CRC of 0. crc32() takes an
+  // unsigned int length, so feed large buffers in UINT_MAX-sized chunks rather
+  // than silently truncating; the running crc makes the split transparent.
+  unsigned long crc = 0;
+  const auto *buf = static_cast<const unsigned char *>(data);
+  while (len > 0) {
+    const unsigned int chunk =
+        len > UINT_MAX ? UINT_MAX : static_cast<unsigned int>(len);
+    crc = crc32(crc, buf, chunk);
+    buf += chunk;
+    len -= chunk;
+  }
+  *crc_out = static_cast<uint32_t>(crc);
   return EFI_STATUS_SUCCESS;
 }
 

--- a/lib/uefi/boot_service_provider.cpp
+++ b/lib/uefi/boot_service_provider.cpp
@@ -507,6 +507,7 @@ void setup_boot_service_table(EfiBootService *service) {
   service->check_event = switch_stack_wrapper<EfiEvent, check_event>();
   service->create_event = create_event;
   service->close_event = close_event;
+  service->set_timer = set_timer;
   service->stall = stall;
   service->raise_tpl = raise_tpl;
   service->restore_tpl = restore_tpl;

--- a/lib/uefi/boot_service_provider.cpp
+++ b/lib/uefi/boot_service_provider.cpp
@@ -17,6 +17,7 @@
 #include "boot_service_provider.h"
 
 #include <endian.h>
+#include <lib/cksum.h>
 #include <lk/compiler.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -258,9 +259,12 @@ EfiStatus uninstall_multiple_protocol_interfaces(EfiHandle handle, ...) {
   printf("%s is unsupported\n", __FUNCTION__);
   return EFI_STATUS_UNSUPPORTED;
 }
-EfiStatus calculate_crc32(void *data, size_t len, uint32_t *crc32) {
-  printf("%s is unsupported\n", __FUNCTION__);
-  return EFI_STATUS_UNSUPPORTED;
+EfiStatus calculate_crc32(void *data, size_t len, uint32_t *crc_out) {
+  if (data == nullptr || crc_out == nullptr || len == 0) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+  *crc_out = crc32(0, static_cast<const unsigned char *>(data), len);
+  return EFI_STATUS_SUCCESS;
 }
 
 EfiStatus uninstall_protocol_interface(EfiHandle handle,

--- a/lib/uefi/boot_service_provider.cpp
+++ b/lib/uefi/boot_service_provider.cpp
@@ -418,6 +418,9 @@ EfiStatus close_protocol(EfiHandle handle, const EfiGuid *protocol,
   } else if (guid_eq(protocol, EFI_DEVICE_PATH_PROTOCOL_GUID)) {
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_BLOCK_IO_PROTOCOL_GUID)) {
+    // Balance the bio reference taken by open_block_device(); teardown still
+    // reclaims any opens the app never closed.
+    close_tracked_bdev(reinterpret_cast<const char *>(handle));
     return EFI_STATUS_SUCCESS;
   } else if (guid_eq(protocol, EFI_DT_FIXUP_PROTOCOL_GUID)) {
     return EFI_STATUS_SUCCESS;

--- a/lib/uefi/memory_protocols.cpp
+++ b/lib/uefi/memory_protocols.cpp
@@ -282,45 +282,41 @@ EfiStatus sync_partition_buffer(struct GblEfiBootMemoryProtocol* self,
   return EFI_STATUS_SUCCESS;
 }
 
+struct BootBufferSlot {
+  GblEfiBootBufferType type;
+  size_t size;
+  size_t align_log2;
+  void* addr;
+};
+
+// 2^21 = 2MB alignment on the load/kernel buffers, required by linux kernel
+BootBufferSlot boot_buffer_slots[] = {
+    {GBL_EFI_BOOT_BUFFER_TYPE_GENERAL_LOAD, 128ul * 1024 * 1024, 21, nullptr},
+    {GBL_EFI_BOOT_BUFFER_TYPE_KERNEL, 64ul * 1024 * 1024, 21, nullptr},
+    {GBL_EFI_BOOT_BUFFER_TYPE_RAMDISK, 64ul * 1024 * 1024, PAGE_SIZE_SHIFT,
+     nullptr},
+    {GBL_EFI_BOOT_BUFFER_TYPE_FDT, 2ul * 1024 * 1024, PAGE_SIZE_SHIFT,
+     nullptr},
+    {GBL_EFI_BOOT_BUFFER_TYPE_PVMFW_DATA, 1024ul * 1024, PAGE_SIZE_SHIFT,
+     nullptr},
+};
+
 EfiStatus get_boot_buffer(struct GblEfiBootMemoryProtocol* self,
                           /* in */ GblEfiBootBufferType buf_type,
                           /* out */ size_t* size,
                           /* out */ void** addr) {
-  if (buf_type == GBL_EFI_BOOT_BUFFER_TYPE_GENERAL_LOAD) {
-    *size = 128ul * 1024 * 1024;
-    // 2^21 = 2MB alignment, required by linux kernel
-    *addr = alloc_page(*size, 21);
-    if (*addr == nullptr) {
+  for (auto& slot : boot_buffer_slots) {
+    if (slot.type != buf_type) {
+      continue;
+    }
+    if (slot.addr == nullptr) {
+      slot.addr = alloc_page(slot.size, slot.align_log2);
+    }
+    if (slot.addr == nullptr) {
       return EFI_STATUS_OUT_OF_RESOURCES;
     }
-    return EFI_STATUS_SUCCESS;
-  } else if (buf_type == GBL_EFI_BOOT_BUFFER_TYPE_KERNEL) {
-    *size = 64ul * 1024 * 1024;
-    *addr = alloc_page(*size, 21);
-    if (*addr == nullptr) {
-      return EFI_STATUS_OUT_OF_RESOURCES;
-    }
-    return EFI_STATUS_SUCCESS;
-  } else if (buf_type == GBL_EFI_BOOT_BUFFER_TYPE_RAMDISK) {
-    *size = 64ul * 1024 * 1024;
-    *addr = alloc_page(*size, PAGE_SIZE_SHIFT);
-    if (*addr == nullptr) {
-      return EFI_STATUS_OUT_OF_RESOURCES;
-    }
-    return EFI_STATUS_SUCCESS;
-  } else if (buf_type == GBL_EFI_BOOT_BUFFER_TYPE_FDT) {
-    *size = 2ul * 1024 * 1024;
-    *addr = alloc_page(*size, PAGE_SIZE_SHIFT);
-    if (*addr == nullptr) {
-      return EFI_STATUS_OUT_OF_RESOURCES;
-    }
-    return EFI_STATUS_SUCCESS;
-  } else if (buf_type == GBL_EFI_BOOT_BUFFER_TYPE_PVMFW_DATA) {
-    *size = 1024ul * 1024;
-    *addr = alloc_page(*size, PAGE_SIZE_SHIFT);
-    if (*addr == nullptr) {
-      return EFI_STATUS_OUT_OF_RESOURCES;
-    }
+    *size = slot.size;
+    *addr = slot.addr;
     return EFI_STATUS_SUCCESS;
   }
   printf("get_boot_buffer(%d, %zu) unsupported\n", buf_type, *size);
@@ -328,6 +324,25 @@ EfiStatus get_boot_buffer(struct GblEfiBootMemoryProtocol* self,
 }
 
 }  // namespace
+
+void release_boot_buffers() {
+  for (auto& slot : boot_buffer_slots) {
+    if (slot.addr == nullptr) {
+      continue;
+    }
+    // Teardown destroys the UEFI address space (reset_heap() runs right after
+    // this), so a retained pointer would be handed back by get_boot_buffer() on
+    // the next run with no valid mapping. Always drop the slot so a fresh,
+    // remapped buffer is allocated next time. free_pages() should succeed now
+    // that pages are returned via paddr_to_kvaddr(); if it ever fails we log it
+    // (the physical pages leak) rather than keep an unusable mapping reusable.
+    if (free_pages(slot.addr, slot.size / PAGE_SIZE) != EFI_STATUS_SUCCESS) {
+      printf("release_boot_buffers: failed to free %p (%zu bytes); dropping "
+             "slot anyway\n", slot.addr, slot.size);
+    }
+    slot.addr = nullptr;
+  }
+}
 
 __WEAK GblEfiBootMemoryProtocol* open_boot_memory_protocol() {
   static GblEfiBootMemoryProtocol protocol = {

--- a/lib/uefi/memory_protocols.h
+++ b/lib/uefi/memory_protocols.h
@@ -27,6 +27,7 @@
 vmm_aspace_t *set_boot_aspace();
 void setup_heap();
 void reset_heap();
+void release_boot_buffers();
 
 EfiStatus allocate_pages(EfiAllocatorType type, EfiMemoryType memory_type,
                          size_t pages, EfiPhysicalAddr *memory);

--- a/lib/uefi/pe.h
+++ b/lib/uefi/pe.h
@@ -41,6 +41,9 @@ static constexpr size_t IMAGE_NUMBEROF_DIRECTORY_ENTRIES = 16;
 static constexpr size_t IMAGE_SIZEOF_SHORT_NAME = 8;
 
 static constexpr uint32_t kPEHeader = 0x4550;
+// IMAGE_FILE_HEADER::Characteristics flag: relocation info was stripped, so the
+// image must be loaded at its preferred ImageBase.
+static constexpr uint16_t IMAGE_FILE_RELOCS_STRIPPED = 0x0001;
 struct IMAGE_NT_HEADERS64;
 
 struct IMAGE_DOS_HEADER { // DOS .EXE header

--- a/lib/uefi/relocation.cpp
+++ b/lib/uefi/relocation.cpp
@@ -11,18 +11,42 @@ int relocate_image(char *image) {
   const auto dos_header = reinterpret_cast<IMAGE_DOS_HEADER *>(image);
   const auto pe_header = dos_header->GetPEHeader();
   const auto optional_header = &pe_header->OptionalHeader;
+  const auto Adjust =
+      reinterpret_cast<size_t>(image - optional_header->ImageBase);
+
+  // DataDirectory[IMAGE_DIRECTORY_ENTRY_BASERELOC] is only valid when the
+  // optional header both declares (NumberOfRvaAndSizes) and physically contains
+  // (SizeOfOptionalHeader) that entry; otherwise indexing it would read
+  // section-table bytes past the header and mis-parse them.
+  constexpr size_t kRelocDirEnd =
+      offsetof(IMAGE_OPTIONAL_HEADER64, DataDirectory) +
+      (IMAGE_DIRECTORY_ENTRY_BASERELOC + 1) * sizeof(IMAGE_DATA_DIRECTORY);
+  const bool have_reloc_dir =
+      optional_header->NumberOfRvaAndSizes > IMAGE_DIRECTORY_ENTRY_BASERELOC &&
+      pe_header->FileHeader.SizeOfOptionalHeader >= kRelocDirEnd;
   const auto reloc_directory =
-      optional_header->DataDirectory[IMAGE_DIRECTORY_ENTRY_BASERELOC];
-  if (reloc_directory.Size == 0) {
-    printf("Relocation section empty\n");
+      have_reloc_dir
+          ? optional_header->DataDirectory[IMAGE_DIRECTORY_ENTRY_BASERELOC]
+          : IMAGE_DATA_DIRECTORY{};
+  if (!have_reloc_dir || reloc_directory.Size == 0) {
+    // No relocations to apply. That is safe only if the image already sits at
+    // its preferred base or is position independent. An image whose relocations
+    // were stripped (IMAGE_FILE_RELOCS_STRIPPED: it must load at ImageBase) that
+    // landed elsewhere would run with unadjusted absolute addresses, so reject
+    // it instead of reporting success.
+    if (Adjust != 0 &&
+        (pe_header->FileHeader.Characteristics & IMAGE_FILE_RELOCS_STRIPPED)) {
+      printf("Image relocations stripped but not loaded at its ImageBase\n");
+      return -1;
+    }
+    printf("%s\n", have_reloc_dir ? "Relocation section empty"
+                                  : "No base relocation directory present");
     return 0;
   }
   auto RelocBase = reinterpret_cast<EFI_IMAGE_BASE_RELOCATION *>(
       image + reloc_directory.VirtualAddress);
   const auto RelocBaseEnd = reinterpret_cast<EFI_IMAGE_BASE_RELOCATION *>(
       reinterpret_cast<char *>(RelocBase) + reloc_directory.Size);
-  const auto Adjust =
-      reinterpret_cast<size_t>(image - optional_header->ImageBase);
   //
   // Run this relocation record
   //
@@ -71,9 +95,11 @@ int relocate_image(char *image) {
         break;
 
       case EFI_IMAGE_REL_BASED_ARM_MOV32A:
+        // ARM MOVW/MOVT instruction encoding is not implemented. Reject the
+        // image rather than letting it reach its entry point with this
+        // relocation left unapplied.
         printf("Unsupported relocation type: EFI_IMAGE_REL_BASED_ARM_MOV32A\n");
-        // break omitted - ARM instruction encoding not implemented
-        break;
+        return -1;
       case EFI_IMAGE_REL_BASED_LOONGARCH64_MARK_LA: {
         // The next four instructions are used to load a 64 bit address,
         // relocate all of them

--- a/lib/uefi/relocation.cpp
+++ b/lib/uefi/relocation.cpp
@@ -7,12 +7,15 @@
 
 #include "pe.h"
 
-int relocate_image(char *image) {
+int relocate_image(char *image, size_t image_size) {
   const auto dos_header = reinterpret_cast<IMAGE_DOS_HEADER *>(image);
   const auto pe_header = dos_header->GetPEHeader();
   const auto optional_header = &pe_header->OptionalHeader;
+  // Compute the load adjustment from integer addresses. Subtracting ImageBase
+  // from the image pointer would form a pointer far outside the allocation
+  // (undefined behavior in C++) whenever ImageBase is nonzero.
   const auto Adjust =
-      reinterpret_cast<size_t>(image - optional_header->ImageBase);
+      reinterpret_cast<size_t>(image) - optional_header->ImageBase;
 
   // DataDirectory[IMAGE_DIRECTORY_ENTRY_BASERELOC] is only valid when the
   // optional header both declares (NumberOfRvaAndSizes) and physically contains
@@ -43,6 +46,13 @@ int relocate_image(char *image) {
                                   : "No base relocation directory present");
     return 0;
   }
+  // The relocation directory is attacker-controlled. Keep the whole region
+  // within the allocated image so a malformed PE cannot walk out of bounds.
+  if (reloc_directory.VirtualAddress > image_size ||
+      reloc_directory.Size > image_size - reloc_directory.VirtualAddress) {
+    printf("Relocation directory out of bounds\n");
+    return -1;
+  }
   auto RelocBase = reinterpret_cast<EFI_IMAGE_BASE_RELOCATION *>(
       image + reloc_directory.VirtualAddress);
   const auto RelocBaseEnd = reinterpret_cast<EFI_IMAGE_BASE_RELOCATION *>(
@@ -50,64 +60,90 @@ int relocate_image(char *image) {
   //
   // Run this relocation record
   //
-  while (RelocBase < RelocBaseEnd) {
+  while (reinterpret_cast<char *>(RelocBase) <
+         reinterpret_cast<char *>(RelocBaseEnd)) {
+    // Each block must hold at least its header and fit within the directory.
+    const size_t block_space = reinterpret_cast<char *>(RelocBaseEnd) -
+                               reinterpret_cast<char *>(RelocBase);
+    if (block_space < sizeof(EFI_IMAGE_BASE_RELOCATION)) {
+      printf("Truncated relocation block header\n");
+      return -1;
+    }
+    const uint32_t size_of_block = RelocBase->SizeOfBlock;
+    if (size_of_block < sizeof(EFI_IMAGE_BASE_RELOCATION) ||
+        size_of_block > block_space) {
+      printf("Found relocation block of invalid size %u\n", size_of_block);
+      return -1;
+    }
     auto Reloc =
         reinterpret_cast<uint16_t *>(reinterpret_cast<char *>(RelocBase) +
                                      sizeof(EFI_IMAGE_BASE_RELOCATION));
     auto RelocEnd = reinterpret_cast<uint16_t *>(
-        reinterpret_cast<char *>(RelocBase) + RelocBase->SizeOfBlock);
-    if (RelocBase->SizeOfBlock == 0) {
-      printf("Found relocation block of size 0, this is wrong\n");
-      return -1;
-    }
+        reinterpret_cast<char *>(RelocBase) + size_of_block);
     while (Reloc < RelocEnd) {
-      auto Fixup = image + RelocBase->VirtualAddress + (*Reloc & 0xFFF);
-      if (Fixup == nullptr) {
-        return 0;
-      }
+      const size_t fixup_off =
+          static_cast<size_t>(RelocBase->VirtualAddress) + (*Reloc & 0xFFF);
+      const auto type = static_cast<uint16_t>(*Reloc >> 12);
 
-      auto Fixup16 = reinterpret_cast<uint16_t *>(Fixup);
-      auto Fixup32 = reinterpret_cast<uint32_t *>(Fixup);
-      auto Fixup64 = reinterpret_cast<uint64_t *>(Fixup);
-      switch ((*Reloc) >> 12) {
+      // Resolve the write width first so the target can be bounds-checked
+      // before any dereference; unsupported types are rejected outright.
+      size_t width = 0;
+      switch (type) {
       case EFI_IMAGE_REL_BASED_ABSOLUTE:
+        width = 0;
         break;
-
       case EFI_IMAGE_REL_BASED_HIGH:
-        *Fixup16 = static_cast<uint16_t>(
-            *Fixup16 +
-            (static_cast<uint16_t>(static_cast<uint32_t>(Adjust) >> 16)));
-
-        break;
-
       case EFI_IMAGE_REL_BASED_LOW:
-        *Fixup16 = static_cast<uint16_t>(
-            *Fixup16 + (static_cast<uint16_t>(Adjust) & 0xffff));
-
+        width = sizeof(uint16_t);
         break;
-
       case EFI_IMAGE_REL_BASED_HIGHLOW:
-        *Fixup32 = *Fixup32 + static_cast<uint32_t>(Adjust);
+        width = sizeof(uint32_t);
         break;
-
       case EFI_IMAGE_REL_BASED_DIR64:
-        *Fixup64 = *Fixup64 + static_cast<uint64_t>(Adjust);
+        width = sizeof(uint64_t);
         break;
-
+      case EFI_IMAGE_REL_BASED_LOONGARCH64_MARK_LA:
+        // Loads a 64-bit address across the next four instructions.
+        width = 4 * sizeof(uint32_t);
+        break;
       case EFI_IMAGE_REL_BASED_ARM_MOV32A:
         // ARM MOVW/MOVT instruction encoding is not implemented. Reject the
         // image rather than letting it reach its entry point with this
         // relocation left unapplied.
         printf("Unsupported relocation type: EFI_IMAGE_REL_BASED_ARM_MOV32A\n");
         return -1;
-      case EFI_IMAGE_REL_BASED_LOONGARCH64_MARK_LA: {
-        // The next four instructions are used to load a 64 bit address,
-        // relocate all of them
-        if (reinterpret_cast<char *>(Fixup32) + 4 * sizeof(uint32_t) > image + optional_header->SizeOfImage) {
-          printf("Relocation out of bounds\n");
-          return -1;
-        }
+      default:
+        printf("Unsupported relocation type: %d\n", type);
+        return -1;
+      }
+      if (fixup_off > image_size || width > image_size - fixup_off) {
+        printf("Relocation out of bounds\n");
+        return -1;
+      }
 
+      char *const Fixup = image + fixup_off;
+      auto Fixup16 = reinterpret_cast<uint16_t *>(Fixup);
+      auto Fixup32 = reinterpret_cast<uint32_t *>(Fixup);
+      auto Fixup64 = reinterpret_cast<uint64_t *>(Fixup);
+      switch (type) {
+      case EFI_IMAGE_REL_BASED_ABSOLUTE:
+        break;
+      case EFI_IMAGE_REL_BASED_HIGH:
+        *Fixup16 = static_cast<uint16_t>(
+            *Fixup16 +
+            (static_cast<uint16_t>(static_cast<uint32_t>(Adjust) >> 16)));
+        break;
+      case EFI_IMAGE_REL_BASED_LOW:
+        *Fixup16 = static_cast<uint16_t>(
+            *Fixup16 + (static_cast<uint16_t>(Adjust) & 0xffff));
+        break;
+      case EFI_IMAGE_REL_BASED_HIGHLOW:
+        *Fixup32 = *Fixup32 + static_cast<uint32_t>(Adjust);
+        break;
+      case EFI_IMAGE_REL_BASED_DIR64:
+        *Fixup64 = *Fixup64 + static_cast<uint64_t>(Adjust);
+        break;
+      case EFI_IMAGE_REL_BASED_LOONGARCH64_MARK_LA: {
         uint64_t Value =
             (*(Fixup32 + 0) & 0x1ffffe0) << 7 |           // lu12i.w 20bits from bit5
             (*(Fixup32 + 1) & 0x3ffc00) >> 10;      // ori     12bits from bit10
@@ -122,9 +158,6 @@ int relocate_image(char *image) {
         *(Fixup32 + 3) = (*(Fixup32 + 3) & ~0x3ffc00) | (((Value >> 52) & 0xfff) << 10);
         break;
       }
-      default:
-        printf("Unsupported relocation type: %d\n", (*Reloc) >> 12);
-        return -1;
       }
 
       //

--- a/lib/uefi/relocation.h
+++ b/lib/uefi/relocation.h
@@ -1,6 +1,8 @@
 #ifndef __LIB_UEFI_RELOCATION_H_
 #define __LIB_UEFI_RELOCATION_H_
 
-int relocate_image(char *image);
+#include <stddef.h>
+
+int relocate_image(char *image, size_t image_size);
 
 #endif

--- a/lib/uefi/runtime_service_provider.cpp
+++ b/lib/uefi/runtime_service_provider.cpp
@@ -95,11 +95,14 @@ EfiStatus SetVirtualAddressMap(size_t MemoryMapSize, size_t DescriptorSize,
 
 EfiStatus SetVariable(const uint16_t* VariableName, const EfiGuid* VendorGuid,
                       uint32_t Attributes, size_t DataSize, const void* Data) {
-  if (!VariableName || VariableName[0] == 0) {
+  if (!VariableName || VariableName[0] == 0 || VendorGuid == nullptr) {
+    return EFI_STATUS_INVALID_PARAMETER;
+  }
+  if (DataSize > 0 && Data == nullptr) {
     return EFI_STATUS_INVALID_PARAMETER;
   }
 
-  /* Only allow setting non-volatile variables */
+  /* Only volatile variables are supported */
   if ((Attributes & EFI_VARIABLE_NON_VOLATILE) == 0) {
     efi_set_variable(reinterpret_cast<const char16_t *>(VariableName),
                      VendorGuid,
@@ -109,7 +112,7 @@ EfiStatus SetVariable(const uint16_t* VariableName, const EfiGuid* VendorGuid,
     return EFI_STATUS_SUCCESS;
   }
 
-  printf("%s: Only non-volatile is supported. Attributes = 0x%x\n",
+  printf("%s: only volatile variables are supported. Attributes = 0x%x\n",
          __FUNCTION__,
          Attributes);
   return EFI_STATUS_UNSUPPORTED;

--- a/lib/uefi/runtime_service_provider.cpp
+++ b/lib/uefi/runtime_service_provider.cpp
@@ -41,28 +41,44 @@ EfiStatus GetVariable(const uint16_t *VariableName, const EfiGuid *VendorGuid,
     i++;
   }
   buffer[i] = 0;
-  if (strncmp(buffer, kSecureBoot, sizeof(kSecureBoot)) == 0 || strcmp(buffer, "SetupMode") == 0) {
-    if (DataSize) {
+  // SecureBoot / SetupMode are architecturally defined under
+  // EFI_GLOBAL_VARIABLE_GUID. Only synthesize them for that namespace; a
+  // same-named variable under a different GUID must fall through to the store.
+  if ((strncmp(buffer, kSecureBoot, sizeof(kSecureBoot)) == 0 ||
+       strcmp(buffer, "SetupMode") == 0) &&
+      memcmp(VendorGuid, &EFI_GLOBAL_VARIABLE_GUID, sizeof(EfiGuid)) == 0) {
+    // Publish the attributes as soon as the variable is recognized, so a
+    // size probe that returns EFI_STATUS_BUFFER_TOO_SMALL reports the same
+    // attributes as a successful read, matching how stored variables behave.
+    if (Attributes != nullptr) {
+      *Attributes = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS;
+    }
+    if (*DataSize < 1) {
       *DataSize = 1;
+      return EFI_STATUS_BUFFER_TOO_SMALL;
     }
-    if (Data) {
-      memset(Data, 0, 1);
+    if (Data == nullptr) {
+      return EFI_STATUS_INVALID_PARAMETER;
     }
+    *DataSize = 1;
+    memset(Data, 0, 1);
     return EFI_STATUS_SUCCESS;
   }
 
   char *data_in_mem;
   size_t data_in_mem_size;
   if (efi_get_variable(reinterpret_cast<const char16_t *>(VariableName), VendorGuid, Attributes, &data_in_mem, &data_in_mem_size) == EFI_STATUS_SUCCESS) {
-    if (*DataSize == 0 && !Data) {
+    if (data_in_mem_size > *DataSize) {
       *DataSize = data_in_mem_size;
       return EFI_STATUS_BUFFER_TOO_SMALL;
     }
-    if (data_in_mem_size > *DataSize) {
-      return EFI_STATUS_BUFFER_TOO_SMALL;
+    if (Data == nullptr && data_in_mem_size > 0) {
+      return EFI_STATUS_INVALID_PARAMETER;
     }
     *DataSize = data_in_mem_size;
-    memcpy(Data, data_in_mem, data_in_mem_size);
+    if (data_in_mem_size > 0) {
+      memcpy(Data, data_in_mem, data_in_mem_size);
+    }
     return EFI_STATUS_SUCCESS;
   }
 

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -55,16 +55,6 @@ constexpr auto EFI_SYSTEM_TABLE_SIGNATURE =
 
 using EfiEntry = int (*)(void *, struct EfiSystemTable *);
 
-template <typename T> void fill(T *data, size_t skip, uint8_t begin = 0) {
-  auto ptr = reinterpret_cast<char *>(data);
-  for (size_t i = 0; i < sizeof(T); i++) {
-    if (i < skip) {
-      continue;
-    }
-    ptr[i] = begin++;
-  }
-}
-
 const char16_t firmwareVendor[] = u"Little Kernel";
 
 class ImageReader {
@@ -180,8 +170,6 @@ int load_sections_and_execute(ImageReader *reader,
   DEFER { free_pages(&table, 1); };
   EfiBootService boot_service{};
   EfiRuntimeService runtime_service{};
-  fill(&runtime_service, 0);
-  fill(&boot_service, 0);
   setup_runtime_service_table(&runtime_service);
   setup_boot_service_table(&boot_service);
   table.firmware_vendor = reinterpret_cast<const EfiChar16*>(firmwareVendor);

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -160,7 +160,10 @@ int load_sections_and_execute(ImageReader *reader,
   }
   printf("Relocating image from 0x%llx to %p\n", optional_header->ImageBase,
          image_base);
-  relocate_image(image_base);
+  if (relocate_image(image_base) != 0) {
+    printf("Failed to relocate image\n");
+    return ERR_BAD_STATE;
+  }
   auto entry = reinterpret_cast<int (*)(void *, void *)>(
       image_base + optional_header->AddressOfEntryPoint);
   printf("Entry function located at %p\n", entry);

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -285,15 +285,20 @@ int load_pe_file(ImageReader *reader) {
   dprintf(INFO, "bio_read returns %d, took %u msecs (%d bytes/sec)\n", (int)err,
           (uint)t, (uint32_t)((uint64_t)err * 1000 / t));
 
+  const size_t header_bytes = static_cast<size_t>(err);
+  if (header_bytes < sizeof(IMAGE_DOS_HEADER)) {
+    printf("File too small for a DOS header: %zu bytes\n", header_bytes);
+    return ERR_BAD_STATE;
+  }
   const auto dos_header = reinterpret_cast<const IMAGE_DOS_HEADER *>(address);
   if (!dos_header->CheckMagic()) {
     printf("DOS Magic check failed %x\n", dos_header->e_magic);
     return ERR_BAD_STATE;
   }
-  if (dos_header->e_lfanew > kBlocKSize - sizeof(IMAGE_FILE_HEADER)) {
+  if (dos_header->e_lfanew > header_bytes - sizeof(IMAGE_FILE_HEADER)) {
     printf(
         "Invalid PE header offset %d exceeds maximum read size of %zu - %zu\n",
-        dos_header->e_lfanew, kBlocKSize, sizeof(IMAGE_FILE_HEADER));
+        dos_header->e_lfanew, header_bytes, sizeof(IMAGE_FILE_HEADER));
     return ERR_BAD_STATE;
   }
   const auto pe_header = dos_header->GetPEHeader();
@@ -315,10 +320,27 @@ int load_pe_file(ImageReader *reader) {
            file_header->SizeOfOptionalHeader, sizeof(IMAGE_OPTIONAL_HEADER64));
     return ERR_BAD_STATE;
   }
+  const size_t nt_headers_end = static_cast<size_t>(dos_header->e_lfanew) +
+                                sizeof(IMAGE_FILE_HEADER) +
+                                file_header->SizeOfOptionalHeader;
+  if (nt_headers_end > header_bytes) {
+    printf("PE optional header does not fit in the %zu bytes read\n",
+           header_bytes);
+    return ERR_BAD_STATE;
+  }
+  const size_t section_table_end =
+      nt_headers_end + static_cast<size_t>(file_header->NumberOfSections) *
+                           sizeof(IMAGE_SECTION_HEADER);
+  if (section_table_end > header_bytes) {
+    printf("PE section table does not fit in the %zu bytes read\n",
+           header_bytes);
+    return ERR_BAD_STATE;
+  }
   const auto optional_header = &pe_header->OptionalHeader;
   if (optional_header->Subsystem != SubsystemType::EFIApplication) {
     printf("Unsupported Subsystem type: %d %s\n", optional_header->Subsystem,
            ToString(optional_header->Subsystem));
+    return ERR_NOT_SUPPORTED;
   }
   printf("Valid UEFI application found.\n");
   auto ret = load_sections_and_execute(reader, pe_header);

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -163,7 +163,7 @@ int load_sections_and_execute(ImageReader *reader,
   }
   printf("Relocating image from 0x%llx to %p\n", optional_header->ImageBase,
          image_base);
-  if (relocate_image(image_base) != 0) {
+  if (relocate_image(image_base, virtual_size) != 0) {
     printf("Failed to relocate image\n");
     return ERR_BAD_STATE;
   }

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -33,6 +33,7 @@
 #include <uefi/runtime_service.h>
 #include <uefi/system_table.h>
 
+#include "blockio_protocols.h"
 #include "boot_service_provider.h"
 #include "charset.h"
 #include "configuration_table.h"
@@ -129,6 +130,7 @@ int load_sections_and_execute(ImageReader *reader,
   setup_heap();
   DEFER { reset_heap(); };
   DEFER { release_boot_buffers(); };
+  DEFER { close_tracked_bdevs(); };
   const auto &last_section = section_header[sections - 1];
   const auto virtual_size = ROUNDUP(
       last_section.VirtualAddress + last_section.Misc.VirtualSize, PAGE_SIZE);

--- a/lib/uefi/uefi.cpp
+++ b/lib/uefi/uefi.cpp
@@ -128,6 +128,7 @@ int load_sections_and_execute(ImageReader *reader,
   }
   setup_heap();
   DEFER { reset_heap(); };
+  DEFER { release_boot_buffers(); };
   const auto &last_section = section_header[sections - 1];
   const auto virtual_size = ROUNDUP(
       last_section.VirtualAddress + last_section.Misc.VirtualSize, PAGE_SIZE);

--- a/lib/uefi/uefi_platform.cpp
+++ b/lib/uefi/uefi_platform.cpp
@@ -33,6 +33,7 @@
 #include <uefi/protocols/random_number_generator_protocol.h>
 #include <uefi/types.h>
 
+#include "blockio_protocols.h"
 #include "defer.h"
 
 #define LOCAL_TRACE 0
@@ -377,7 +378,10 @@ __WEAK EfiStatus open_efi_erase_block_protocol(EfiHandle handle, const void** in
     return EFI_STATUS_OUT_OF_RESOURCES;
   }
   memset(p, 0, sizeof(*p));
-  p->dev = bio_open(device_name);
+  EfiStatus status = open_tracked_bdev(device_name, &p->dev);
+  if (status != EFI_STATUS_SUCCESS) {
+    return status;
+  }
   p->protocol = {
       .revision = EFI_ERASE_BLOCK_PROTOCOL_REVISION,
       .erase_length_granularity = 1,  // Erase block size == 1 filesystem block

--- a/lib/uefi/variable_mem.cpp
+++ b/lib/uefi/variable_mem.cpp
@@ -87,6 +87,18 @@ void efi_set_variable(const char16_t *variable_name,
                       size_t data_len) {
   struct EfiVariable *var = search_existing_variable(variable_name, guid);
 
+  /* A zero-size write deletes the variable, but only when this is not an
+   * append. With EFI_VARIABLE_APPEND_WRITE set, appending zero bytes is a
+   * no-op that must leave any existing value unchanged. */
+  if (data_len == 0) {
+    if ((attribute & EFI_VARIABLE_APPEND_WRITE) == 0 && var) {
+      list_delete(&var->node);
+      free(var->Data);
+      free(var);
+    }
+    return;
+  }
+
   /* alloc new variable if it is not existed */
   if (!var) {
     var = reinterpret_cast<struct EfiVariable *>(malloc(sizeof(struct EfiVariable)));

--- a/lib/uefi/variable_mem.cpp
+++ b/lib/uefi/variable_mem.cpp
@@ -110,17 +110,31 @@ void efi_set_variable(const char16_t *variable_name,
     memcpy(var->VariableName, variable_name, name_len * sizeof(char16_t));
     list_add_tail(&variables_in_mem, &var->node);
   }
-  if (var->Data) {
+  /* EFI_VARIABLE_APPEND_WRITE concatenates onto the existing value; a plain
+   * write replaces it. (The data_len == 0 cases were handled above.) */
+  const bool append = (attribute & EFI_VARIABLE_APPEND_WRITE) != 0;
+  if (append && var->Data != nullptr && var->DataLen > 0) {
+    const size_t combined_len = var->DataLen + data_len;
+    char *combined = reinterpret_cast<char *>(malloc(combined_len));
+    if (combined == nullptr) {
+      /* Out of memory: leave the existing value intact instead of losing it. */
+      return;
+    }
+    memcpy(combined, var->Data, var->DataLen);
+    memcpy(combined + var->DataLen, data, data_len);
     free(var->Data);
-  }
-  var->Data = nullptr;
-  var->DataLen = 0;
-  if (data_len > 0) {
+    var->Data = combined;
+    var->DataLen = combined_len;
+  } else {
+    if (var->Data) {
+      free(var->Data);
+    }
     var->Data = reinterpret_cast<char *>(malloc(data_len));
     memcpy(var->Data, data, data_len);
     var->DataLen = data_len;
   }
-  var->Attributes = attribute;
+  /* The append bit is a per-call modifier, not stored variable state. */
+  var->Attributes = attribute & ~EFI_VARIABLE_APPEND_WRITE;
   if (guid) {
     memcpy(&var->VendorGuid, guid, sizeof(EfiGuid));
   }

--- a/lib/uefi/variable_mem.h
+++ b/lib/uefi/variable_mem.h
@@ -30,6 +30,9 @@ static constexpr uint32_t EFI_VARIABLE_NON_VOLATILE = 0x01;
 static constexpr uint32_t EFI_VARIABLE_BOOTSERVICE_ACCESS = 0x02;
 static constexpr uint32_t EFI_VARIABLE_RUNTIME_ACCESS = 0x04;
 static constexpr uint32_t EFI_VARIABLE_HARDWARE_ERROR_RECORD = 0x08;
+static constexpr uint32_t EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS = 0x10;
+static constexpr uint32_t EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS = 0x20;
+static constexpr uint32_t EFI_VARIABLE_APPEND_WRITE = 0x40;
 
 EfiStatus efi_get_variable(const char16_t *variable_name,
                            const EfiGuid *guid,


### PR DESCRIPTION
Correctness and resource-lifetime fixes in lib/uefi.

Service tables and loader behavior:

* **leave unimplemented service table slots null**: the boot/runtime service tables were pre-filled with an incrementing byte pattern, so calling an unimplemented service jumped to a garbage address. With value-initialized tables the unimplemented slots stay null, which applications can test for, and a stray call faults at address zero instead of a random location. The existing `set_timer` stub is now actually installed in the table (it was never wired up).
* **make synchronous block writes report unsupported**: `write_blocks`/`flush_blocks` returned `EFI_STATUS_SUCCESS` without touching the device, so applications believed their writes had been persisted. They now return `EFI_STATUS_UNSUPPORTED`, matching the async path (`write_blocks_ex`).
* **abort the load when relocation fails**: `load_sections_and_execute()` ignored `relocate_image()`'s result and jumped to the entry point of a partially relocated image.
* **bound PE header parsing to the bytes actually read**: the parser only checked `e_lfanew` against the file header size; a truncated or malformed image could place the optional header or the section table beyond the bytes the reader returned (parsing uninitialized heap) or beyond the 4 KiB buffer entirely. Every region is now checked against the bytes actually read, and a non-EFI-application subsystem is rejected instead of only warned about.

Variable services:

* **follow the spec in get_variable**: report the required size when returning `EFI_STATUS_BUFFER_TOO_SMALL`, return `EFI_STATUS_INVALID_PARAMETER` instead of copying through a null `Data` pointer, honor `*DataSize` for the synthesized SecureBoot/SetupMode answers instead of writing a byte unconditionally, and report attributes for them.
* **tighten set_variable parameter checks and deletion**: reject a null `VendorGuid` (the store would otherwise match a same-named variable under any GUID) and a non-zero `DataSize` with null `Data`; per spec, a zero `DataSize` now deletes the variable instead of leaving an empty one behind. Also fixes the inverted comment/error message (the code accepts only volatile variables).

Resource lifetime:

* **reuse and release boot memory protocol buffers**: `get_boot_buffer` allocated a fresh buffer on every call and nothing ever released them, so an app that returned to the shell (e.g. a fastboot session that never boots) leaked up to 259 MiB of contiguous pages per run. One buffer per type is now cached, repeated requests get the same buffer, and everything is released at run teardown.
* **close block devices when a run ends**: `open_block_device`, `open_async_block_device`, and `open_efi_erase_block_protocol` called `bio_open` with no matching `bio_close`, leaking a device reference per protocol open per run. Opens are now tracked and closed at run teardown, and a missing device fails cleanly with `EFI_STATUS_NOT_FOUND` instead of dereferencing a null bdev.
* **implement calculate_crc32**: wired to lib/cksum's CRC-32 (already used for the EFI system table pointer checksum) instead of returning `EFI_STATUS_UNSUPPORTED`.

Validation (qemu-virt-arm64-test, Clang/LLD, WERROR=1):

* `helloworld_aa64.efi` loads and runs (return code 0), `uefi_set_var`/`uefi_list_var` behave as before, `ut all` passes 36/36, no faults in the log
* Also validated with #530 and #531 applied on top: two consecutive `uefi_load` runs both succeed, PMM `free_count` identical before/after, `ut all` 36/36
